### PR TITLE
ARCH-1615 - Actions maintenance

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,8 +5,10 @@ on:
   # trigger because checkout, build, format and checking for changes do not need elevated
   # permissions to the repository.  The reduced permissions for public forks is adequate.
   pull_request:
-    paths-ignore:
-      - '**.md'
+    # Don't include any specific paths here so we always get a build that produces a status
+    # check that our Branch Protection Rules can use.  Having a status check also allows us
+    # to require that branches be up to date before they are merged.
+
 jobs:
   build:
     runs-on: ${{ matrix.operating-system }}
@@ -17,11 +19,11 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - name: Setup Node.js 14
-        uses: actions/setup-node@v1
+        uses: actions/checkout@v3
+      - name: Setup Node.js 16
+        uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 16.x
       - name: Build
         run: npm run build
       - name: Format

--- a/.github/workflows/increment-version-on-merge.yml
+++ b/.github/workflows/increment-version-on-merge.yml
@@ -43,7 +43,7 @@ jobs:
       # See https://github.com/im-open/git-version-lite for more details around how to increment
       # major/minor/patch through commit messages
       - name: Increment the version
-        uses: im-open/git-version-lite@v2.1.0
+        uses: im-open/git-version-lite@v2.1.1
         with:
           create-ref: true
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/increment-version-on-merge.yml
+++ b/.github/workflows/increment-version-on-merge.yml
@@ -15,6 +15,12 @@ on:
   #      reviewed, approved by a CODEOWNER and merged
   pull_request_target:
     types: [closed]
+    paths:
+      - 'dist/**'
+      - 'src/**'
+      - 'action.yml'
+      - 'package.json'
+      - 'package-lock.json'
 
 jobs:
   increment-version:
@@ -28,7 +34,7 @@ jobs:
       # on a pull_request_target.  But we need to be extra careful not to trigger any script
       # that may operate on PR controlled contents like in the case of npm install.
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: main
           fetch-depth: 0
@@ -37,7 +43,7 @@ jobs:
       # See https://github.com/im-open/git-version-lite for more details around how to increment
       # major/minor/patch through commit messages
       - name: Increment the version
-        uses: im-open/git-version-lite@v2.0.6
+        uses: im-open/git-version-lite@v2.1.0
         with:
           create-ref: true
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,8 +5,10 @@ on:
   # trigger because checkout, build, format and checking for changes do not need elevated
   # permissions to the repository.  The reduced permissions for public forks is adequate.
   pull_request:
-    paths-ignore:
-      - '**.md'
+    # Don't include any specific paths here so we always get a build that produces a status
+    # check that our Branch Protection Rules can use.  Having a status check also allows us
+    # to require that branches be up to date before they are merged.
+
 jobs:
   test-flyway-version-514:
     runs-on: ${{ matrix.operating-system }}
@@ -17,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Flyway
         uses: ./
@@ -41,7 +43,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Flyway
         uses: ./

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Flyway
-        uses: im-open/setup-flyway@v1.0.4
+        uses: im-open/setup-flyway@v1.1.0
         with:
           version: 5.1.4
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Flyway
         uses: im-open/setup-flyway@v1.0.4

--- a/action.yml
+++ b/action.yml
@@ -10,5 +10,5 @@ inputs:
     description: 'Target operating system architecture for Flyway to use. Examples: x86, x64. Will use system architecture by default.'
     required: false
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -18,6 +18,7 @@ var require_utils = __commonJS({
   'node_modules/@actions/core/lib/utils.js'(exports2) {
     'use strict';
     Object.defineProperty(exports2, '__esModule', { value: true });
+    exports2.toCommandProperties = exports2.toCommandValue = void 0;
     function toCommandValue(input) {
       if (input === null || input === void 0) {
         return '';
@@ -27,6 +28,20 @@ var require_utils = __commonJS({
       return JSON.stringify(input);
     }
     exports2.toCommandValue = toCommandValue;
+    function toCommandProperties(annotationProperties) {
+      if (!Object.keys(annotationProperties).length) {
+        return {};
+      }
+      return {
+        title: annotationProperties.title,
+        file: annotationProperties.file,
+        line: annotationProperties.startLine,
+        endLine: annotationProperties.endLine,
+        col: annotationProperties.startColumn,
+        endColumn: annotationProperties.endColumn
+      };
+    }
+    exports2.toCommandProperties = toCommandProperties;
   }
 });
 
@@ -34,18 +49,46 @@ var require_utils = __commonJS({
 var require_command = __commonJS({
   'node_modules/@actions/core/lib/command.js'(exports2) {
     'use strict';
+    var __createBinding =
+      (exports2 && exports2.__createBinding) ||
+      (Object.create
+        ? function (o, m, k, k2) {
+            if (k2 === void 0) k2 = k;
+            Object.defineProperty(o, k2, {
+              enumerable: true,
+              get: function () {
+                return m[k];
+              }
+            });
+          }
+        : function (o, m, k, k2) {
+            if (k2 === void 0) k2 = k;
+            o[k2] = m[k];
+          });
+    var __setModuleDefault =
+      (exports2 && exports2.__setModuleDefault) ||
+      (Object.create
+        ? function (o, v) {
+            Object.defineProperty(o, 'default', { enumerable: true, value: v });
+          }
+        : function (o, v) {
+            o['default'] = v;
+          });
     var __importStar =
       (exports2 && exports2.__importStar) ||
       function (mod) {
         if (mod && mod.__esModule) return mod;
         var result = {};
         if (mod != null) {
-          for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
+          for (var k in mod)
+            if (k !== 'default' && Object.hasOwnProperty.call(mod, k))
+              __createBinding(result, mod, k);
         }
-        result['default'] = mod;
+        __setModuleDefault(result, mod);
         return result;
       };
     Object.defineProperty(exports2, '__esModule', { value: true });
+    exports2.issue = exports2.issueCommand = void 0;
     var os3 = __importStar(require('os'));
     var utils_1 = require_utils();
     function issueCommand(command, properties, message) {
@@ -109,26 +152,574 @@ var require_command = __commonJS({
   }
 });
 
+// node_modules/@actions/core/node_modules/uuid/dist/rng.js
+var require_rng = __commonJS({
+  'node_modules/@actions/core/node_modules/uuid/dist/rng.js'(exports2) {
+    'use strict';
+    Object.defineProperty(exports2, '__esModule', {
+      value: true
+    });
+    exports2.default = rng;
+    var _crypto = _interopRequireDefault(require('crypto'));
+    function _interopRequireDefault(obj) {
+      return obj && obj.__esModule ? obj : { default: obj };
+    }
+    var rnds8Pool = new Uint8Array(256);
+    var poolPtr = rnds8Pool.length;
+    function rng() {
+      if (poolPtr > rnds8Pool.length - 16) {
+        _crypto.default.randomFillSync(rnds8Pool);
+        poolPtr = 0;
+      }
+      return rnds8Pool.slice(poolPtr, (poolPtr += 16));
+    }
+  }
+});
+
+// node_modules/@actions/core/node_modules/uuid/dist/regex.js
+var require_regex = __commonJS({
+  'node_modules/@actions/core/node_modules/uuid/dist/regex.js'(exports2) {
+    'use strict';
+    Object.defineProperty(exports2, '__esModule', {
+      value: true
+    });
+    exports2.default = void 0;
+    var _default =
+      /^(?:[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}|00000000-0000-0000-0000-000000000000)$/i;
+    exports2.default = _default;
+  }
+});
+
+// node_modules/@actions/core/node_modules/uuid/dist/validate.js
+var require_validate = __commonJS({
+  'node_modules/@actions/core/node_modules/uuid/dist/validate.js'(exports2) {
+    'use strict';
+    Object.defineProperty(exports2, '__esModule', {
+      value: true
+    });
+    exports2.default = void 0;
+    var _regex = _interopRequireDefault(require_regex());
+    function _interopRequireDefault(obj) {
+      return obj && obj.__esModule ? obj : { default: obj };
+    }
+    function validate(uuid) {
+      return typeof uuid === 'string' && _regex.default.test(uuid);
+    }
+    var _default = validate;
+    exports2.default = _default;
+  }
+});
+
+// node_modules/@actions/core/node_modules/uuid/dist/stringify.js
+var require_stringify = __commonJS({
+  'node_modules/@actions/core/node_modules/uuid/dist/stringify.js'(exports2) {
+    'use strict';
+    Object.defineProperty(exports2, '__esModule', {
+      value: true
+    });
+    exports2.default = void 0;
+    var _validate = _interopRequireDefault(require_validate());
+    function _interopRequireDefault(obj) {
+      return obj && obj.__esModule ? obj : { default: obj };
+    }
+    var byteToHex = [];
+    for (let i = 0; i < 256; ++i) {
+      byteToHex.push((i + 256).toString(16).substr(1));
+    }
+    function stringify(arr, offset = 0) {
+      const uuid = (
+        byteToHex[arr[offset + 0]] +
+        byteToHex[arr[offset + 1]] +
+        byteToHex[arr[offset + 2]] +
+        byteToHex[arr[offset + 3]] +
+        '-' +
+        byteToHex[arr[offset + 4]] +
+        byteToHex[arr[offset + 5]] +
+        '-' +
+        byteToHex[arr[offset + 6]] +
+        byteToHex[arr[offset + 7]] +
+        '-' +
+        byteToHex[arr[offset + 8]] +
+        byteToHex[arr[offset + 9]] +
+        '-' +
+        byteToHex[arr[offset + 10]] +
+        byteToHex[arr[offset + 11]] +
+        byteToHex[arr[offset + 12]] +
+        byteToHex[arr[offset + 13]] +
+        byteToHex[arr[offset + 14]] +
+        byteToHex[arr[offset + 15]]
+      ).toLowerCase();
+      if (!(0, _validate.default)(uuid)) {
+        throw TypeError('Stringified UUID is invalid');
+      }
+      return uuid;
+    }
+    var _default = stringify;
+    exports2.default = _default;
+  }
+});
+
+// node_modules/@actions/core/node_modules/uuid/dist/v1.js
+var require_v1 = __commonJS({
+  'node_modules/@actions/core/node_modules/uuid/dist/v1.js'(exports2) {
+    'use strict';
+    Object.defineProperty(exports2, '__esModule', {
+      value: true
+    });
+    exports2.default = void 0;
+    var _rng = _interopRequireDefault(require_rng());
+    var _stringify = _interopRequireDefault(require_stringify());
+    function _interopRequireDefault(obj) {
+      return obj && obj.__esModule ? obj : { default: obj };
+    }
+    var _nodeId;
+    var _clockseq;
+    var _lastMSecs = 0;
+    var _lastNSecs = 0;
+    function v1(options, buf, offset) {
+      let i = (buf && offset) || 0;
+      const b = buf || new Array(16);
+      options = options || {};
+      let node = options.node || _nodeId;
+      let clockseq = options.clockseq !== void 0 ? options.clockseq : _clockseq;
+      if (node == null || clockseq == null) {
+        const seedBytes = options.random || (options.rng || _rng.default)();
+        if (node == null) {
+          node = _nodeId = [
+            seedBytes[0] | 1,
+            seedBytes[1],
+            seedBytes[2],
+            seedBytes[3],
+            seedBytes[4],
+            seedBytes[5]
+          ];
+        }
+        if (clockseq == null) {
+          clockseq = _clockseq = ((seedBytes[6] << 8) | seedBytes[7]) & 16383;
+        }
+      }
+      let msecs = options.msecs !== void 0 ? options.msecs : Date.now();
+      let nsecs = options.nsecs !== void 0 ? options.nsecs : _lastNSecs + 1;
+      const dt = msecs - _lastMSecs + (nsecs - _lastNSecs) / 1e4;
+      if (dt < 0 && options.clockseq === void 0) {
+        clockseq = (clockseq + 1) & 16383;
+      }
+      if ((dt < 0 || msecs > _lastMSecs) && options.nsecs === void 0) {
+        nsecs = 0;
+      }
+      if (nsecs >= 1e4) {
+        throw new Error("uuid.v1(): Can't create more than 10M uuids/sec");
+      }
+      _lastMSecs = msecs;
+      _lastNSecs = nsecs;
+      _clockseq = clockseq;
+      msecs += 122192928e5;
+      const tl = ((msecs & 268435455) * 1e4 + nsecs) % 4294967296;
+      b[i++] = (tl >>> 24) & 255;
+      b[i++] = (tl >>> 16) & 255;
+      b[i++] = (tl >>> 8) & 255;
+      b[i++] = tl & 255;
+      const tmh = ((msecs / 4294967296) * 1e4) & 268435455;
+      b[i++] = (tmh >>> 8) & 255;
+      b[i++] = tmh & 255;
+      b[i++] = ((tmh >>> 24) & 15) | 16;
+      b[i++] = (tmh >>> 16) & 255;
+      b[i++] = (clockseq >>> 8) | 128;
+      b[i++] = clockseq & 255;
+      for (let n = 0; n < 6; ++n) {
+        b[i + n] = node[n];
+      }
+      return buf || (0, _stringify.default)(b);
+    }
+    var _default = v1;
+    exports2.default = _default;
+  }
+});
+
+// node_modules/@actions/core/node_modules/uuid/dist/parse.js
+var require_parse = __commonJS({
+  'node_modules/@actions/core/node_modules/uuid/dist/parse.js'(exports2) {
+    'use strict';
+    Object.defineProperty(exports2, '__esModule', {
+      value: true
+    });
+    exports2.default = void 0;
+    var _validate = _interopRequireDefault(require_validate());
+    function _interopRequireDefault(obj) {
+      return obj && obj.__esModule ? obj : { default: obj };
+    }
+    function parse(uuid) {
+      if (!(0, _validate.default)(uuid)) {
+        throw TypeError('Invalid UUID');
+      }
+      let v;
+      const arr = new Uint8Array(16);
+      arr[0] = (v = parseInt(uuid.slice(0, 8), 16)) >>> 24;
+      arr[1] = (v >>> 16) & 255;
+      arr[2] = (v >>> 8) & 255;
+      arr[3] = v & 255;
+      arr[4] = (v = parseInt(uuid.slice(9, 13), 16)) >>> 8;
+      arr[5] = v & 255;
+      arr[6] = (v = parseInt(uuid.slice(14, 18), 16)) >>> 8;
+      arr[7] = v & 255;
+      arr[8] = (v = parseInt(uuid.slice(19, 23), 16)) >>> 8;
+      arr[9] = v & 255;
+      arr[10] = ((v = parseInt(uuid.slice(24, 36), 16)) / 1099511627776) & 255;
+      arr[11] = (v / 4294967296) & 255;
+      arr[12] = (v >>> 24) & 255;
+      arr[13] = (v >>> 16) & 255;
+      arr[14] = (v >>> 8) & 255;
+      arr[15] = v & 255;
+      return arr;
+    }
+    var _default = parse;
+    exports2.default = _default;
+  }
+});
+
+// node_modules/@actions/core/node_modules/uuid/dist/v35.js
+var require_v35 = __commonJS({
+  'node_modules/@actions/core/node_modules/uuid/dist/v35.js'(exports2) {
+    'use strict';
+    Object.defineProperty(exports2, '__esModule', {
+      value: true
+    });
+    exports2.default = _default;
+    exports2.URL = exports2.DNS = void 0;
+    var _stringify = _interopRequireDefault(require_stringify());
+    var _parse = _interopRequireDefault(require_parse());
+    function _interopRequireDefault(obj) {
+      return obj && obj.__esModule ? obj : { default: obj };
+    }
+    function stringToBytes(str) {
+      str = unescape(encodeURIComponent(str));
+      const bytes = [];
+      for (let i = 0; i < str.length; ++i) {
+        bytes.push(str.charCodeAt(i));
+      }
+      return bytes;
+    }
+    var DNS = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';
+    exports2.DNS = DNS;
+    var URL2 = '6ba7b811-9dad-11d1-80b4-00c04fd430c8';
+    exports2.URL = URL2;
+    function _default(name, version, hashfunc) {
+      function generateUUID(value, namespace, buf, offset) {
+        if (typeof value === 'string') {
+          value = stringToBytes(value);
+        }
+        if (typeof namespace === 'string') {
+          namespace = (0, _parse.default)(namespace);
+        }
+        if (namespace.length !== 16) {
+          throw TypeError('Namespace must be array-like (16 iterable integer values, 0-255)');
+        }
+        let bytes = new Uint8Array(16 + value.length);
+        bytes.set(namespace);
+        bytes.set(value, namespace.length);
+        bytes = hashfunc(bytes);
+        bytes[6] = (bytes[6] & 15) | version;
+        bytes[8] = (bytes[8] & 63) | 128;
+        if (buf) {
+          offset = offset || 0;
+          for (let i = 0; i < 16; ++i) {
+            buf[offset + i] = bytes[i];
+          }
+          return buf;
+        }
+        return (0, _stringify.default)(bytes);
+      }
+      try {
+        generateUUID.name = name;
+      } catch (err) {}
+      generateUUID.DNS = DNS;
+      generateUUID.URL = URL2;
+      return generateUUID;
+    }
+  }
+});
+
+// node_modules/@actions/core/node_modules/uuid/dist/md5.js
+var require_md5 = __commonJS({
+  'node_modules/@actions/core/node_modules/uuid/dist/md5.js'(exports2) {
+    'use strict';
+    Object.defineProperty(exports2, '__esModule', {
+      value: true
+    });
+    exports2.default = void 0;
+    var _crypto = _interopRequireDefault(require('crypto'));
+    function _interopRequireDefault(obj) {
+      return obj && obj.__esModule ? obj : { default: obj };
+    }
+    function md5(bytes) {
+      if (Array.isArray(bytes)) {
+        bytes = Buffer.from(bytes);
+      } else if (typeof bytes === 'string') {
+        bytes = Buffer.from(bytes, 'utf8');
+      }
+      return _crypto.default.createHash('md5').update(bytes).digest();
+    }
+    var _default = md5;
+    exports2.default = _default;
+  }
+});
+
+// node_modules/@actions/core/node_modules/uuid/dist/v3.js
+var require_v3 = __commonJS({
+  'node_modules/@actions/core/node_modules/uuid/dist/v3.js'(exports2) {
+    'use strict';
+    Object.defineProperty(exports2, '__esModule', {
+      value: true
+    });
+    exports2.default = void 0;
+    var _v = _interopRequireDefault(require_v35());
+    var _md = _interopRequireDefault(require_md5());
+    function _interopRequireDefault(obj) {
+      return obj && obj.__esModule ? obj : { default: obj };
+    }
+    var v3 = (0, _v.default)('v3', 48, _md.default);
+    var _default = v3;
+    exports2.default = _default;
+  }
+});
+
+// node_modules/@actions/core/node_modules/uuid/dist/v4.js
+var require_v4 = __commonJS({
+  'node_modules/@actions/core/node_modules/uuid/dist/v4.js'(exports2) {
+    'use strict';
+    Object.defineProperty(exports2, '__esModule', {
+      value: true
+    });
+    exports2.default = void 0;
+    var _rng = _interopRequireDefault(require_rng());
+    var _stringify = _interopRequireDefault(require_stringify());
+    function _interopRequireDefault(obj) {
+      return obj && obj.__esModule ? obj : { default: obj };
+    }
+    function v4(options, buf, offset) {
+      options = options || {};
+      const rnds = options.random || (options.rng || _rng.default)();
+      rnds[6] = (rnds[6] & 15) | 64;
+      rnds[8] = (rnds[8] & 63) | 128;
+      if (buf) {
+        offset = offset || 0;
+        for (let i = 0; i < 16; ++i) {
+          buf[offset + i] = rnds[i];
+        }
+        return buf;
+      }
+      return (0, _stringify.default)(rnds);
+    }
+    var _default = v4;
+    exports2.default = _default;
+  }
+});
+
+// node_modules/@actions/core/node_modules/uuid/dist/sha1.js
+var require_sha1 = __commonJS({
+  'node_modules/@actions/core/node_modules/uuid/dist/sha1.js'(exports2) {
+    'use strict';
+    Object.defineProperty(exports2, '__esModule', {
+      value: true
+    });
+    exports2.default = void 0;
+    var _crypto = _interopRequireDefault(require('crypto'));
+    function _interopRequireDefault(obj) {
+      return obj && obj.__esModule ? obj : { default: obj };
+    }
+    function sha1(bytes) {
+      if (Array.isArray(bytes)) {
+        bytes = Buffer.from(bytes);
+      } else if (typeof bytes === 'string') {
+        bytes = Buffer.from(bytes, 'utf8');
+      }
+      return _crypto.default.createHash('sha1').update(bytes).digest();
+    }
+    var _default = sha1;
+    exports2.default = _default;
+  }
+});
+
+// node_modules/@actions/core/node_modules/uuid/dist/v5.js
+var require_v5 = __commonJS({
+  'node_modules/@actions/core/node_modules/uuid/dist/v5.js'(exports2) {
+    'use strict';
+    Object.defineProperty(exports2, '__esModule', {
+      value: true
+    });
+    exports2.default = void 0;
+    var _v = _interopRequireDefault(require_v35());
+    var _sha = _interopRequireDefault(require_sha1());
+    function _interopRequireDefault(obj) {
+      return obj && obj.__esModule ? obj : { default: obj };
+    }
+    var v5 = (0, _v.default)('v5', 80, _sha.default);
+    var _default = v5;
+    exports2.default = _default;
+  }
+});
+
+// node_modules/@actions/core/node_modules/uuid/dist/nil.js
+var require_nil = __commonJS({
+  'node_modules/@actions/core/node_modules/uuid/dist/nil.js'(exports2) {
+    'use strict';
+    Object.defineProperty(exports2, '__esModule', {
+      value: true
+    });
+    exports2.default = void 0;
+    var _default = '00000000-0000-0000-0000-000000000000';
+    exports2.default = _default;
+  }
+});
+
+// node_modules/@actions/core/node_modules/uuid/dist/version.js
+var require_version = __commonJS({
+  'node_modules/@actions/core/node_modules/uuid/dist/version.js'(exports2) {
+    'use strict';
+    Object.defineProperty(exports2, '__esModule', {
+      value: true
+    });
+    exports2.default = void 0;
+    var _validate = _interopRequireDefault(require_validate());
+    function _interopRequireDefault(obj) {
+      return obj && obj.__esModule ? obj : { default: obj };
+    }
+    function version(uuid) {
+      if (!(0, _validate.default)(uuid)) {
+        throw TypeError('Invalid UUID');
+      }
+      return parseInt(uuid.substr(14, 1), 16);
+    }
+    var _default = version;
+    exports2.default = _default;
+  }
+});
+
+// node_modules/@actions/core/node_modules/uuid/dist/index.js
+var require_dist = __commonJS({
+  'node_modules/@actions/core/node_modules/uuid/dist/index.js'(exports2) {
+    'use strict';
+    Object.defineProperty(exports2, '__esModule', {
+      value: true
+    });
+    Object.defineProperty(exports2, 'v1', {
+      enumerable: true,
+      get: function () {
+        return _v.default;
+      }
+    });
+    Object.defineProperty(exports2, 'v3', {
+      enumerable: true,
+      get: function () {
+        return _v2.default;
+      }
+    });
+    Object.defineProperty(exports2, 'v4', {
+      enumerable: true,
+      get: function () {
+        return _v3.default;
+      }
+    });
+    Object.defineProperty(exports2, 'v5', {
+      enumerable: true,
+      get: function () {
+        return _v4.default;
+      }
+    });
+    Object.defineProperty(exports2, 'NIL', {
+      enumerable: true,
+      get: function () {
+        return _nil.default;
+      }
+    });
+    Object.defineProperty(exports2, 'version', {
+      enumerable: true,
+      get: function () {
+        return _version.default;
+      }
+    });
+    Object.defineProperty(exports2, 'validate', {
+      enumerable: true,
+      get: function () {
+        return _validate.default;
+      }
+    });
+    Object.defineProperty(exports2, 'stringify', {
+      enumerable: true,
+      get: function () {
+        return _stringify.default;
+      }
+    });
+    Object.defineProperty(exports2, 'parse', {
+      enumerable: true,
+      get: function () {
+        return _parse.default;
+      }
+    });
+    var _v = _interopRequireDefault(require_v1());
+    var _v2 = _interopRequireDefault(require_v3());
+    var _v3 = _interopRequireDefault(require_v4());
+    var _v4 = _interopRequireDefault(require_v5());
+    var _nil = _interopRequireDefault(require_nil());
+    var _version = _interopRequireDefault(require_version());
+    var _validate = _interopRequireDefault(require_validate());
+    var _stringify = _interopRequireDefault(require_stringify());
+    var _parse = _interopRequireDefault(require_parse());
+    function _interopRequireDefault(obj) {
+      return obj && obj.__esModule ? obj : { default: obj };
+    }
+  }
+});
+
 // node_modules/@actions/core/lib/file-command.js
 var require_file_command = __commonJS({
   'node_modules/@actions/core/lib/file-command.js'(exports2) {
     'use strict';
+    var __createBinding =
+      (exports2 && exports2.__createBinding) ||
+      (Object.create
+        ? function (o, m, k, k2) {
+            if (k2 === void 0) k2 = k;
+            Object.defineProperty(o, k2, {
+              enumerable: true,
+              get: function () {
+                return m[k];
+              }
+            });
+          }
+        : function (o, m, k, k2) {
+            if (k2 === void 0) k2 = k;
+            o[k2] = m[k];
+          });
+    var __setModuleDefault =
+      (exports2 && exports2.__setModuleDefault) ||
+      (Object.create
+        ? function (o, v) {
+            Object.defineProperty(o, 'default', { enumerable: true, value: v });
+          }
+        : function (o, v) {
+            o['default'] = v;
+          });
     var __importStar =
       (exports2 && exports2.__importStar) ||
       function (mod) {
         if (mod && mod.__esModule) return mod;
         var result = {};
         if (mod != null) {
-          for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
+          for (var k in mod)
+            if (k !== 'default' && Object.hasOwnProperty.call(mod, k))
+              __createBinding(result, mod, k);
         }
-        result['default'] = mod;
+        __setModuleDefault(result, mod);
         return result;
       };
     Object.defineProperty(exports2, '__esModule', { value: true });
+    exports2.prepareKeyValueMessage = exports2.issueFileCommand = void 0;
     var fs2 = __importStar(require('fs'));
     var os3 = __importStar(require('os'));
+    var uuid_1 = require_dist();
     var utils_1 = require_utils();
-    function issueCommand(command, message) {
+    function issueFileCommand(command, message) {
       const filePath = process.env[`GITHUB_${command}`];
       if (!filePath) {
         throw new Error(`Unable to find environment variable for file command ${command}`);
@@ -140,13 +731,955 @@ var require_file_command = __commonJS({
         encoding: 'utf8'
       });
     }
-    exports2.issueCommand = issueCommand;
+    exports2.issueFileCommand = issueFileCommand;
+    function prepareKeyValueMessage(key, value) {
+      const delimiter = `ghadelimiter_${uuid_1.v4()}`;
+      const convertedValue = utils_1.toCommandValue(value);
+      if (key.includes(delimiter)) {
+        throw new Error(`Unexpected input: name should not contain the delimiter "${delimiter}"`);
+      }
+      if (convertedValue.includes(delimiter)) {
+        throw new Error(`Unexpected input: value should not contain the delimiter "${delimiter}"`);
+      }
+      return `${key}<<${delimiter}${os3.EOL}${convertedValue}${os3.EOL}${delimiter}`;
+    }
+    exports2.prepareKeyValueMessage = prepareKeyValueMessage;
   }
 });
 
-// node_modules/@actions/core/lib/core.js
-var require_core = __commonJS({
-  'node_modules/@actions/core/lib/core.js'(exports2) {
+// node_modules/@actions/core/node_modules/@actions/http-client/lib/proxy.js
+var require_proxy = __commonJS({
+  'node_modules/@actions/core/node_modules/@actions/http-client/lib/proxy.js'(exports2) {
+    'use strict';
+    Object.defineProperty(exports2, '__esModule', { value: true });
+    exports2.checkBypass = exports2.getProxyUrl = void 0;
+    function getProxyUrl(reqUrl) {
+      const usingSsl = reqUrl.protocol === 'https:';
+      if (checkBypass(reqUrl)) {
+        return void 0;
+      }
+      const proxyVar = (() => {
+        if (usingSsl) {
+          return process.env['https_proxy'] || process.env['HTTPS_PROXY'];
+        } else {
+          return process.env['http_proxy'] || process.env['HTTP_PROXY'];
+        }
+      })();
+      if (proxyVar) {
+        return new URL(proxyVar);
+      } else {
+        return void 0;
+      }
+    }
+    exports2.getProxyUrl = getProxyUrl;
+    function checkBypass(reqUrl) {
+      if (!reqUrl.hostname) {
+        return false;
+      }
+      const noProxy = process.env['no_proxy'] || process.env['NO_PROXY'] || '';
+      if (!noProxy) {
+        return false;
+      }
+      let reqPort;
+      if (reqUrl.port) {
+        reqPort = Number(reqUrl.port);
+      } else if (reqUrl.protocol === 'http:') {
+        reqPort = 80;
+      } else if (reqUrl.protocol === 'https:') {
+        reqPort = 443;
+      }
+      const upperReqHosts = [reqUrl.hostname.toUpperCase()];
+      if (typeof reqPort === 'number') {
+        upperReqHosts.push(`${upperReqHosts[0]}:${reqPort}`);
+      }
+      for (const upperNoProxyItem of noProxy
+        .split(',')
+        .map(x => x.trim().toUpperCase())
+        .filter(x => x)) {
+        if (upperReqHosts.some(x => x === upperNoProxyItem)) {
+          return true;
+        }
+      }
+      return false;
+    }
+    exports2.checkBypass = checkBypass;
+  }
+});
+
+// node_modules/tunnel/lib/tunnel.js
+var require_tunnel = __commonJS({
+  'node_modules/tunnel/lib/tunnel.js'(exports2) {
+    'use strict';
+    var net = require('net');
+    var tls = require('tls');
+    var http = require('http');
+    var https = require('https');
+    var events = require('events');
+    var assert = require('assert');
+    var util = require('util');
+    exports2.httpOverHttp = httpOverHttp;
+    exports2.httpsOverHttp = httpsOverHttp;
+    exports2.httpOverHttps = httpOverHttps;
+    exports2.httpsOverHttps = httpsOverHttps;
+    function httpOverHttp(options) {
+      var agent = new TunnelingAgent(options);
+      agent.request = http.request;
+      return agent;
+    }
+    function httpsOverHttp(options) {
+      var agent = new TunnelingAgent(options);
+      agent.request = http.request;
+      agent.createSocket = createSecureSocket;
+      agent.defaultPort = 443;
+      return agent;
+    }
+    function httpOverHttps(options) {
+      var agent = new TunnelingAgent(options);
+      agent.request = https.request;
+      return agent;
+    }
+    function httpsOverHttps(options) {
+      var agent = new TunnelingAgent(options);
+      agent.request = https.request;
+      agent.createSocket = createSecureSocket;
+      agent.defaultPort = 443;
+      return agent;
+    }
+    function TunnelingAgent(options) {
+      var self = this;
+      self.options = options || {};
+      self.proxyOptions = self.options.proxy || {};
+      self.maxSockets = self.options.maxSockets || http.Agent.defaultMaxSockets;
+      self.requests = [];
+      self.sockets = [];
+      self.on('free', function onFree(socket, host, port, localAddress) {
+        var options2 = toOptions(host, port, localAddress);
+        for (var i = 0, len = self.requests.length; i < len; ++i) {
+          var pending = self.requests[i];
+          if (pending.host === options2.host && pending.port === options2.port) {
+            self.requests.splice(i, 1);
+            pending.request.onSocket(socket);
+            return;
+          }
+        }
+        socket.destroy();
+        self.removeSocket(socket);
+      });
+    }
+    util.inherits(TunnelingAgent, events.EventEmitter);
+    TunnelingAgent.prototype.addRequest = function addRequest(req, host, port, localAddress) {
+      var self = this;
+      var options = mergeOptions(
+        { request: req },
+        self.options,
+        toOptions(host, port, localAddress)
+      );
+      if (self.sockets.length >= this.maxSockets) {
+        self.requests.push(options);
+        return;
+      }
+      self.createSocket(options, function (socket) {
+        socket.on('free', onFree);
+        socket.on('close', onCloseOrRemove);
+        socket.on('agentRemove', onCloseOrRemove);
+        req.onSocket(socket);
+        function onFree() {
+          self.emit('free', socket, options);
+        }
+        function onCloseOrRemove(err) {
+          self.removeSocket(socket);
+          socket.removeListener('free', onFree);
+          socket.removeListener('close', onCloseOrRemove);
+          socket.removeListener('agentRemove', onCloseOrRemove);
+        }
+      });
+    };
+    TunnelingAgent.prototype.createSocket = function createSocket(options, cb) {
+      var self = this;
+      var placeholder = {};
+      self.sockets.push(placeholder);
+      var connectOptions = mergeOptions({}, self.proxyOptions, {
+        method: 'CONNECT',
+        path: options.host + ':' + options.port,
+        agent: false,
+        headers: {
+          host: options.host + ':' + options.port
+        }
+      });
+      if (options.localAddress) {
+        connectOptions.localAddress = options.localAddress;
+      }
+      if (connectOptions.proxyAuth) {
+        connectOptions.headers = connectOptions.headers || {};
+        connectOptions.headers['Proxy-Authorization'] =
+          'Basic ' + new Buffer(connectOptions.proxyAuth).toString('base64');
+      }
+      debug('making CONNECT request');
+      var connectReq = self.request(connectOptions);
+      connectReq.useChunkedEncodingByDefault = false;
+      connectReq.once('response', onResponse);
+      connectReq.once('upgrade', onUpgrade);
+      connectReq.once('connect', onConnect);
+      connectReq.once('error', onError);
+      connectReq.end();
+      function onResponse(res) {
+        res.upgrade = true;
+      }
+      function onUpgrade(res, socket, head) {
+        process.nextTick(function () {
+          onConnect(res, socket, head);
+        });
+      }
+      function onConnect(res, socket, head) {
+        connectReq.removeAllListeners();
+        socket.removeAllListeners();
+        if (res.statusCode !== 200) {
+          debug('tunneling socket could not be established, statusCode=%d', res.statusCode);
+          socket.destroy();
+          var error = new Error(
+            'tunneling socket could not be established, statusCode=' + res.statusCode
+          );
+          error.code = 'ECONNRESET';
+          options.request.emit('error', error);
+          self.removeSocket(placeholder);
+          return;
+        }
+        if (head.length > 0) {
+          debug('got illegal response body from proxy');
+          socket.destroy();
+          var error = new Error('got illegal response body from proxy');
+          error.code = 'ECONNRESET';
+          options.request.emit('error', error);
+          self.removeSocket(placeholder);
+          return;
+        }
+        debug('tunneling connection has established');
+        self.sockets[self.sockets.indexOf(placeholder)] = socket;
+        return cb(socket);
+      }
+      function onError(cause) {
+        connectReq.removeAllListeners();
+        debug('tunneling socket could not be established, cause=%s\n', cause.message, cause.stack);
+        var error = new Error('tunneling socket could not be established, cause=' + cause.message);
+        error.code = 'ECONNRESET';
+        options.request.emit('error', error);
+        self.removeSocket(placeholder);
+      }
+    };
+    TunnelingAgent.prototype.removeSocket = function removeSocket(socket) {
+      var pos = this.sockets.indexOf(socket);
+      if (pos === -1) {
+        return;
+      }
+      this.sockets.splice(pos, 1);
+      var pending = this.requests.shift();
+      if (pending) {
+        this.createSocket(pending, function (socket2) {
+          pending.request.onSocket(socket2);
+        });
+      }
+    };
+    function createSecureSocket(options, cb) {
+      var self = this;
+      TunnelingAgent.prototype.createSocket.call(self, options, function (socket) {
+        var hostHeader = options.request.getHeader('host');
+        var tlsOptions = mergeOptions({}, self.options, {
+          socket,
+          servername: hostHeader ? hostHeader.replace(/:.*$/, '') : options.host
+        });
+        var secureSocket = tls.connect(0, tlsOptions);
+        self.sockets[self.sockets.indexOf(socket)] = secureSocket;
+        cb(secureSocket);
+      });
+    }
+    function toOptions(host, port, localAddress) {
+      if (typeof host === 'string') {
+        return {
+          host,
+          port,
+          localAddress
+        };
+      }
+      return host;
+    }
+    function mergeOptions(target) {
+      for (var i = 1, len = arguments.length; i < len; ++i) {
+        var overrides = arguments[i];
+        if (typeof overrides === 'object') {
+          var keys = Object.keys(overrides);
+          for (var j = 0, keyLen = keys.length; j < keyLen; ++j) {
+            var k = keys[j];
+            if (overrides[k] !== void 0) {
+              target[k] = overrides[k];
+            }
+          }
+        }
+      }
+      return target;
+    }
+    var debug;
+    if (process.env.NODE_DEBUG && /\btunnel\b/.test(process.env.NODE_DEBUG)) {
+      debug = function () {
+        var args = Array.prototype.slice.call(arguments);
+        if (typeof args[0] === 'string') {
+          args[0] = 'TUNNEL: ' + args[0];
+        } else {
+          args.unshift('TUNNEL:');
+        }
+        console.error.apply(console, args);
+      };
+    } else {
+      debug = function () {};
+    }
+    exports2.debug = debug;
+  }
+});
+
+// node_modules/tunnel/index.js
+var require_tunnel2 = __commonJS({
+  'node_modules/tunnel/index.js'(exports2, module2) {
+    module2.exports = require_tunnel();
+  }
+});
+
+// node_modules/@actions/core/node_modules/@actions/http-client/lib/index.js
+var require_lib = __commonJS({
+  'node_modules/@actions/core/node_modules/@actions/http-client/lib/index.js'(exports2) {
+    'use strict';
+    var __createBinding =
+      (exports2 && exports2.__createBinding) ||
+      (Object.create
+        ? function (o, m, k, k2) {
+            if (k2 === void 0) k2 = k;
+            Object.defineProperty(o, k2, {
+              enumerable: true,
+              get: function () {
+                return m[k];
+              }
+            });
+          }
+        : function (o, m, k, k2) {
+            if (k2 === void 0) k2 = k;
+            o[k2] = m[k];
+          });
+    var __setModuleDefault =
+      (exports2 && exports2.__setModuleDefault) ||
+      (Object.create
+        ? function (o, v) {
+            Object.defineProperty(o, 'default', { enumerable: true, value: v });
+          }
+        : function (o, v) {
+            o['default'] = v;
+          });
+    var __importStar =
+      (exports2 && exports2.__importStar) ||
+      function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) {
+          for (var k in mod)
+            if (k !== 'default' && Object.hasOwnProperty.call(mod, k))
+              __createBinding(result, mod, k);
+        }
+        __setModuleDefault(result, mod);
+        return result;
+      };
+    var __awaiter =
+      (exports2 && exports2.__awaiter) ||
+      function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+          return value instanceof P
+            ? value
+            : new P(function (resolve) {
+                resolve(value);
+              });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+          function fulfilled(value) {
+            try {
+              step(generator.next(value));
+            } catch (e) {
+              reject(e);
+            }
+          }
+          function rejected(value) {
+            try {
+              step(generator['throw'](value));
+            } catch (e) {
+              reject(e);
+            }
+          }
+          function step(result) {
+            result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+          }
+          step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+      };
+    Object.defineProperty(exports2, '__esModule', { value: true });
+    exports2.HttpClient =
+      exports2.isHttps =
+      exports2.HttpClientResponse =
+      exports2.HttpClientError =
+      exports2.getProxyUrl =
+      exports2.MediaTypes =
+      exports2.Headers =
+      exports2.HttpCodes =
+        void 0;
+    var http = __importStar(require('http'));
+    var https = __importStar(require('https'));
+    var pm = __importStar(require_proxy());
+    var tunnel = __importStar(require_tunnel2());
+    var HttpCodes;
+    (function (HttpCodes2) {
+      HttpCodes2[(HttpCodes2['OK'] = 200)] = 'OK';
+      HttpCodes2[(HttpCodes2['MultipleChoices'] = 300)] = 'MultipleChoices';
+      HttpCodes2[(HttpCodes2['MovedPermanently'] = 301)] = 'MovedPermanently';
+      HttpCodes2[(HttpCodes2['ResourceMoved'] = 302)] = 'ResourceMoved';
+      HttpCodes2[(HttpCodes2['SeeOther'] = 303)] = 'SeeOther';
+      HttpCodes2[(HttpCodes2['NotModified'] = 304)] = 'NotModified';
+      HttpCodes2[(HttpCodes2['UseProxy'] = 305)] = 'UseProxy';
+      HttpCodes2[(HttpCodes2['SwitchProxy'] = 306)] = 'SwitchProxy';
+      HttpCodes2[(HttpCodes2['TemporaryRedirect'] = 307)] = 'TemporaryRedirect';
+      HttpCodes2[(HttpCodes2['PermanentRedirect'] = 308)] = 'PermanentRedirect';
+      HttpCodes2[(HttpCodes2['BadRequest'] = 400)] = 'BadRequest';
+      HttpCodes2[(HttpCodes2['Unauthorized'] = 401)] = 'Unauthorized';
+      HttpCodes2[(HttpCodes2['PaymentRequired'] = 402)] = 'PaymentRequired';
+      HttpCodes2[(HttpCodes2['Forbidden'] = 403)] = 'Forbidden';
+      HttpCodes2[(HttpCodes2['NotFound'] = 404)] = 'NotFound';
+      HttpCodes2[(HttpCodes2['MethodNotAllowed'] = 405)] = 'MethodNotAllowed';
+      HttpCodes2[(HttpCodes2['NotAcceptable'] = 406)] = 'NotAcceptable';
+      HttpCodes2[(HttpCodes2['ProxyAuthenticationRequired'] = 407)] = 'ProxyAuthenticationRequired';
+      HttpCodes2[(HttpCodes2['RequestTimeout'] = 408)] = 'RequestTimeout';
+      HttpCodes2[(HttpCodes2['Conflict'] = 409)] = 'Conflict';
+      HttpCodes2[(HttpCodes2['Gone'] = 410)] = 'Gone';
+      HttpCodes2[(HttpCodes2['TooManyRequests'] = 429)] = 'TooManyRequests';
+      HttpCodes2[(HttpCodes2['InternalServerError'] = 500)] = 'InternalServerError';
+      HttpCodes2[(HttpCodes2['NotImplemented'] = 501)] = 'NotImplemented';
+      HttpCodes2[(HttpCodes2['BadGateway'] = 502)] = 'BadGateway';
+      HttpCodes2[(HttpCodes2['ServiceUnavailable'] = 503)] = 'ServiceUnavailable';
+      HttpCodes2[(HttpCodes2['GatewayTimeout'] = 504)] = 'GatewayTimeout';
+    })((HttpCodes = exports2.HttpCodes || (exports2.HttpCodes = {})));
+    var Headers;
+    (function (Headers2) {
+      Headers2['Accept'] = 'accept';
+      Headers2['ContentType'] = 'content-type';
+    })((Headers = exports2.Headers || (exports2.Headers = {})));
+    var MediaTypes;
+    (function (MediaTypes2) {
+      MediaTypes2['ApplicationJson'] = 'application/json';
+    })((MediaTypes = exports2.MediaTypes || (exports2.MediaTypes = {})));
+    function getProxyUrl(serverUrl) {
+      const proxyUrl = pm.getProxyUrl(new URL(serverUrl));
+      return proxyUrl ? proxyUrl.href : '';
+    }
+    exports2.getProxyUrl = getProxyUrl;
+    var HttpRedirectCodes = [
+      HttpCodes.MovedPermanently,
+      HttpCodes.ResourceMoved,
+      HttpCodes.SeeOther,
+      HttpCodes.TemporaryRedirect,
+      HttpCodes.PermanentRedirect
+    ];
+    var HttpResponseRetryCodes = [
+      HttpCodes.BadGateway,
+      HttpCodes.ServiceUnavailable,
+      HttpCodes.GatewayTimeout
+    ];
+    var RetryableHttpVerbs = ['OPTIONS', 'GET', 'DELETE', 'HEAD'];
+    var ExponentialBackoffCeiling = 10;
+    var ExponentialBackoffTimeSlice = 5;
+    var HttpClientError = class extends Error {
+      constructor(message, statusCode) {
+        super(message);
+        this.name = 'HttpClientError';
+        this.statusCode = statusCode;
+        Object.setPrototypeOf(this, HttpClientError.prototype);
+      }
+    };
+    exports2.HttpClientError = HttpClientError;
+    var HttpClientResponse = class {
+      constructor(message) {
+        this.message = message;
+      }
+      readBody() {
+        return __awaiter(this, void 0, void 0, function* () {
+          return new Promise(resolve =>
+            __awaiter(this, void 0, void 0, function* () {
+              let output = Buffer.alloc(0);
+              this.message.on('data', chunk => {
+                output = Buffer.concat([output, chunk]);
+              });
+              this.message.on('end', () => {
+                resolve(output.toString());
+              });
+            })
+          );
+        });
+      }
+    };
+    exports2.HttpClientResponse = HttpClientResponse;
+    function isHttps(requestUrl) {
+      const parsedUrl = new URL(requestUrl);
+      return parsedUrl.protocol === 'https:';
+    }
+    exports2.isHttps = isHttps;
+    var HttpClient = class {
+      constructor(userAgent, handlers, requestOptions) {
+        this._ignoreSslError = false;
+        this._allowRedirects = true;
+        this._allowRedirectDowngrade = false;
+        this._maxRedirects = 50;
+        this._allowRetries = false;
+        this._maxRetries = 1;
+        this._keepAlive = false;
+        this._disposed = false;
+        this.userAgent = userAgent;
+        this.handlers = handlers || [];
+        this.requestOptions = requestOptions;
+        if (requestOptions) {
+          if (requestOptions.ignoreSslError != null) {
+            this._ignoreSslError = requestOptions.ignoreSslError;
+          }
+          this._socketTimeout = requestOptions.socketTimeout;
+          if (requestOptions.allowRedirects != null) {
+            this._allowRedirects = requestOptions.allowRedirects;
+          }
+          if (requestOptions.allowRedirectDowngrade != null) {
+            this._allowRedirectDowngrade = requestOptions.allowRedirectDowngrade;
+          }
+          if (requestOptions.maxRedirects != null) {
+            this._maxRedirects = Math.max(requestOptions.maxRedirects, 0);
+          }
+          if (requestOptions.keepAlive != null) {
+            this._keepAlive = requestOptions.keepAlive;
+          }
+          if (requestOptions.allowRetries != null) {
+            this._allowRetries = requestOptions.allowRetries;
+          }
+          if (requestOptions.maxRetries != null) {
+            this._maxRetries = requestOptions.maxRetries;
+          }
+        }
+      }
+      options(requestUrl, additionalHeaders) {
+        return __awaiter(this, void 0, void 0, function* () {
+          return this.request('OPTIONS', requestUrl, null, additionalHeaders || {});
+        });
+      }
+      get(requestUrl, additionalHeaders) {
+        return __awaiter(this, void 0, void 0, function* () {
+          return this.request('GET', requestUrl, null, additionalHeaders || {});
+        });
+      }
+      del(requestUrl, additionalHeaders) {
+        return __awaiter(this, void 0, void 0, function* () {
+          return this.request('DELETE', requestUrl, null, additionalHeaders || {});
+        });
+      }
+      post(requestUrl, data, additionalHeaders) {
+        return __awaiter(this, void 0, void 0, function* () {
+          return this.request('POST', requestUrl, data, additionalHeaders || {});
+        });
+      }
+      patch(requestUrl, data, additionalHeaders) {
+        return __awaiter(this, void 0, void 0, function* () {
+          return this.request('PATCH', requestUrl, data, additionalHeaders || {});
+        });
+      }
+      put(requestUrl, data, additionalHeaders) {
+        return __awaiter(this, void 0, void 0, function* () {
+          return this.request('PUT', requestUrl, data, additionalHeaders || {});
+        });
+      }
+      head(requestUrl, additionalHeaders) {
+        return __awaiter(this, void 0, void 0, function* () {
+          return this.request('HEAD', requestUrl, null, additionalHeaders || {});
+        });
+      }
+      sendStream(verb, requestUrl, stream, additionalHeaders) {
+        return __awaiter(this, void 0, void 0, function* () {
+          return this.request(verb, requestUrl, stream, additionalHeaders);
+        });
+      }
+      getJson(requestUrl, additionalHeaders = {}) {
+        return __awaiter(this, void 0, void 0, function* () {
+          additionalHeaders[Headers.Accept] = this._getExistingOrDefaultHeader(
+            additionalHeaders,
+            Headers.Accept,
+            MediaTypes.ApplicationJson
+          );
+          const res = yield this.get(requestUrl, additionalHeaders);
+          return this._processResponse(res, this.requestOptions);
+        });
+      }
+      postJson(requestUrl, obj, additionalHeaders = {}) {
+        return __awaiter(this, void 0, void 0, function* () {
+          const data = JSON.stringify(obj, null, 2);
+          additionalHeaders[Headers.Accept] = this._getExistingOrDefaultHeader(
+            additionalHeaders,
+            Headers.Accept,
+            MediaTypes.ApplicationJson
+          );
+          additionalHeaders[Headers.ContentType] = this._getExistingOrDefaultHeader(
+            additionalHeaders,
+            Headers.ContentType,
+            MediaTypes.ApplicationJson
+          );
+          const res = yield this.post(requestUrl, data, additionalHeaders);
+          return this._processResponse(res, this.requestOptions);
+        });
+      }
+      putJson(requestUrl, obj, additionalHeaders = {}) {
+        return __awaiter(this, void 0, void 0, function* () {
+          const data = JSON.stringify(obj, null, 2);
+          additionalHeaders[Headers.Accept] = this._getExistingOrDefaultHeader(
+            additionalHeaders,
+            Headers.Accept,
+            MediaTypes.ApplicationJson
+          );
+          additionalHeaders[Headers.ContentType] = this._getExistingOrDefaultHeader(
+            additionalHeaders,
+            Headers.ContentType,
+            MediaTypes.ApplicationJson
+          );
+          const res = yield this.put(requestUrl, data, additionalHeaders);
+          return this._processResponse(res, this.requestOptions);
+        });
+      }
+      patchJson(requestUrl, obj, additionalHeaders = {}) {
+        return __awaiter(this, void 0, void 0, function* () {
+          const data = JSON.stringify(obj, null, 2);
+          additionalHeaders[Headers.Accept] = this._getExistingOrDefaultHeader(
+            additionalHeaders,
+            Headers.Accept,
+            MediaTypes.ApplicationJson
+          );
+          additionalHeaders[Headers.ContentType] = this._getExistingOrDefaultHeader(
+            additionalHeaders,
+            Headers.ContentType,
+            MediaTypes.ApplicationJson
+          );
+          const res = yield this.patch(requestUrl, data, additionalHeaders);
+          return this._processResponse(res, this.requestOptions);
+        });
+      }
+      request(verb, requestUrl, data, headers) {
+        return __awaiter(this, void 0, void 0, function* () {
+          if (this._disposed) {
+            throw new Error('Client has already been disposed.');
+          }
+          const parsedUrl = new URL(requestUrl);
+          let info = this._prepareRequest(verb, parsedUrl, headers);
+          const maxTries =
+            this._allowRetries && RetryableHttpVerbs.includes(verb) ? this._maxRetries + 1 : 1;
+          let numTries = 0;
+          let response;
+          do {
+            response = yield this.requestRaw(info, data);
+            if (
+              response &&
+              response.message &&
+              response.message.statusCode === HttpCodes.Unauthorized
+            ) {
+              let authenticationHandler;
+              for (const handler of this.handlers) {
+                if (handler.canHandleAuthentication(response)) {
+                  authenticationHandler = handler;
+                  break;
+                }
+              }
+              if (authenticationHandler) {
+                return authenticationHandler.handleAuthentication(this, info, data);
+              } else {
+                return response;
+              }
+            }
+            let redirectsRemaining = this._maxRedirects;
+            while (
+              response.message.statusCode &&
+              HttpRedirectCodes.includes(response.message.statusCode) &&
+              this._allowRedirects &&
+              redirectsRemaining > 0
+            ) {
+              const redirectUrl = response.message.headers['location'];
+              if (!redirectUrl) {
+                break;
+              }
+              const parsedRedirectUrl = new URL(redirectUrl);
+              if (
+                parsedUrl.protocol === 'https:' &&
+                parsedUrl.protocol !== parsedRedirectUrl.protocol &&
+                !this._allowRedirectDowngrade
+              ) {
+                throw new Error(
+                  'Redirect from HTTPS to HTTP protocol. This downgrade is not allowed for security reasons. If you want to allow this behavior, set the allowRedirectDowngrade option to true.'
+                );
+              }
+              yield response.readBody();
+              if (parsedRedirectUrl.hostname !== parsedUrl.hostname) {
+                for (const header in headers) {
+                  if (header.toLowerCase() === 'authorization') {
+                    delete headers[header];
+                  }
+                }
+              }
+              info = this._prepareRequest(verb, parsedRedirectUrl, headers);
+              response = yield this.requestRaw(info, data);
+              redirectsRemaining--;
+            }
+            if (
+              !response.message.statusCode ||
+              !HttpResponseRetryCodes.includes(response.message.statusCode)
+            ) {
+              return response;
+            }
+            numTries += 1;
+            if (numTries < maxTries) {
+              yield response.readBody();
+              yield this._performExponentialBackoff(numTries);
+            }
+          } while (numTries < maxTries);
+          return response;
+        });
+      }
+      dispose() {
+        if (this._agent) {
+          this._agent.destroy();
+        }
+        this._disposed = true;
+      }
+      requestRaw(info, data) {
+        return __awaiter(this, void 0, void 0, function* () {
+          return new Promise((resolve, reject) => {
+            function callbackForResult(err, res) {
+              if (err) {
+                reject(err);
+              } else if (!res) {
+                reject(new Error('Unknown error'));
+              } else {
+                resolve(res);
+              }
+            }
+            this.requestRawWithCallback(info, data, callbackForResult);
+          });
+        });
+      }
+      requestRawWithCallback(info, data, onResult) {
+        if (typeof data === 'string') {
+          if (!info.options.headers) {
+            info.options.headers = {};
+          }
+          info.options.headers['Content-Length'] = Buffer.byteLength(data, 'utf8');
+        }
+        let callbackCalled = false;
+        function handleResult(err, res) {
+          if (!callbackCalled) {
+            callbackCalled = true;
+            onResult(err, res);
+          }
+        }
+        const req = info.httpModule.request(info.options, msg => {
+          const res = new HttpClientResponse(msg);
+          handleResult(void 0, res);
+        });
+        let socket;
+        req.on('socket', sock => {
+          socket = sock;
+        });
+        req.setTimeout(this._socketTimeout || 3 * 6e4, () => {
+          if (socket) {
+            socket.end();
+          }
+          handleResult(new Error(`Request timeout: ${info.options.path}`));
+        });
+        req.on('error', function (err) {
+          handleResult(err);
+        });
+        if (data && typeof data === 'string') {
+          req.write(data, 'utf8');
+        }
+        if (data && typeof data !== 'string') {
+          data.on('close', function () {
+            req.end();
+          });
+          data.pipe(req);
+        } else {
+          req.end();
+        }
+      }
+      getAgent(serverUrl) {
+        const parsedUrl = new URL(serverUrl);
+        return this._getAgent(parsedUrl);
+      }
+      _prepareRequest(method, requestUrl, headers) {
+        const info = {};
+        info.parsedUrl = requestUrl;
+        const usingSsl = info.parsedUrl.protocol === 'https:';
+        info.httpModule = usingSsl ? https : http;
+        const defaultPort = usingSsl ? 443 : 80;
+        info.options = {};
+        info.options.host = info.parsedUrl.hostname;
+        info.options.port = info.parsedUrl.port ? parseInt(info.parsedUrl.port) : defaultPort;
+        info.options.path = (info.parsedUrl.pathname || '') + (info.parsedUrl.search || '');
+        info.options.method = method;
+        info.options.headers = this._mergeHeaders(headers);
+        if (this.userAgent != null) {
+          info.options.headers['user-agent'] = this.userAgent;
+        }
+        info.options.agent = this._getAgent(info.parsedUrl);
+        if (this.handlers) {
+          for (const handler of this.handlers) {
+            handler.prepareRequest(info.options);
+          }
+        }
+        return info;
+      }
+      _mergeHeaders(headers) {
+        if (this.requestOptions && this.requestOptions.headers) {
+          return Object.assign(
+            {},
+            lowercaseKeys(this.requestOptions.headers),
+            lowercaseKeys(headers || {})
+          );
+        }
+        return lowercaseKeys(headers || {});
+      }
+      _getExistingOrDefaultHeader(additionalHeaders, header, _default) {
+        let clientHeader;
+        if (this.requestOptions && this.requestOptions.headers) {
+          clientHeader = lowercaseKeys(this.requestOptions.headers)[header];
+        }
+        return additionalHeaders[header] || clientHeader || _default;
+      }
+      _getAgent(parsedUrl) {
+        let agent;
+        const proxyUrl = pm.getProxyUrl(parsedUrl);
+        const useProxy = proxyUrl && proxyUrl.hostname;
+        if (this._keepAlive && useProxy) {
+          agent = this._proxyAgent;
+        }
+        if (this._keepAlive && !useProxy) {
+          agent = this._agent;
+        }
+        if (agent) {
+          return agent;
+        }
+        const usingSsl = parsedUrl.protocol === 'https:';
+        let maxSockets = 100;
+        if (this.requestOptions) {
+          maxSockets = this.requestOptions.maxSockets || http.globalAgent.maxSockets;
+        }
+        if (proxyUrl && proxyUrl.hostname) {
+          const agentOptions = {
+            maxSockets,
+            keepAlive: this._keepAlive,
+            proxy: Object.assign(
+              Object.assign(
+                {},
+                (proxyUrl.username || proxyUrl.password) && {
+                  proxyAuth: `${proxyUrl.username}:${proxyUrl.password}`
+                }
+              ),
+              { host: proxyUrl.hostname, port: proxyUrl.port }
+            )
+          };
+          let tunnelAgent;
+          const overHttps = proxyUrl.protocol === 'https:';
+          if (usingSsl) {
+            tunnelAgent = overHttps ? tunnel.httpsOverHttps : tunnel.httpsOverHttp;
+          } else {
+            tunnelAgent = overHttps ? tunnel.httpOverHttps : tunnel.httpOverHttp;
+          }
+          agent = tunnelAgent(agentOptions);
+          this._proxyAgent = agent;
+        }
+        if (this._keepAlive && !agent) {
+          const options = { keepAlive: this._keepAlive, maxSockets };
+          agent = usingSsl ? new https.Agent(options) : new http.Agent(options);
+          this._agent = agent;
+        }
+        if (!agent) {
+          agent = usingSsl ? https.globalAgent : http.globalAgent;
+        }
+        if (usingSsl && this._ignoreSslError) {
+          agent.options = Object.assign(agent.options || {}, {
+            rejectUnauthorized: false
+          });
+        }
+        return agent;
+      }
+      _performExponentialBackoff(retryNumber) {
+        return __awaiter(this, void 0, void 0, function* () {
+          retryNumber = Math.min(ExponentialBackoffCeiling, retryNumber);
+          const ms = ExponentialBackoffTimeSlice * Math.pow(2, retryNumber);
+          return new Promise(resolve => setTimeout(() => resolve(), ms));
+        });
+      }
+      _processResponse(res, options) {
+        return __awaiter(this, void 0, void 0, function* () {
+          return new Promise((resolve, reject) =>
+            __awaiter(this, void 0, void 0, function* () {
+              const statusCode = res.message.statusCode || 0;
+              const response = {
+                statusCode,
+                result: null,
+                headers: {}
+              };
+              if (statusCode === HttpCodes.NotFound) {
+                resolve(response);
+              }
+              function dateTimeDeserializer(key, value) {
+                if (typeof value === 'string') {
+                  const a = new Date(value);
+                  if (!isNaN(a.valueOf())) {
+                    return a;
+                  }
+                }
+                return value;
+              }
+              let obj;
+              let contents;
+              try {
+                contents = yield res.readBody();
+                if (contents && contents.length > 0) {
+                  if (options && options.deserializeDates) {
+                    obj = JSON.parse(contents, dateTimeDeserializer);
+                  } else {
+                    obj = JSON.parse(contents);
+                  }
+                  response.result = obj;
+                }
+                response.headers = res.message.headers;
+              } catch (err) {}
+              if (statusCode > 299) {
+                let msg;
+                if (obj && obj.message) {
+                  msg = obj.message;
+                } else if (contents && contents.length > 0) {
+                  msg = contents;
+                } else {
+                  msg = `Failed request: (${statusCode})`;
+                }
+                const err = new HttpClientError(msg, statusCode);
+                err.result = response.result;
+                reject(err);
+              } else {
+                resolve(response);
+              }
+            })
+          );
+        });
+      }
+    };
+    exports2.HttpClient = HttpClient;
+    var lowercaseKeys = obj =>
+      Object.keys(obj).reduce((c, k) => ((c[k.toLowerCase()] = obj[k]), c), {});
+  }
+});
+
+// node_modules/@actions/core/node_modules/@actions/http-client/lib/auth.js
+var require_auth = __commonJS({
+  'node_modules/@actions/core/node_modules/@actions/http-client/lib/auth.js'(exports2) {
     'use strict';
     var __awaiter =
       (exports2 && exports2.__awaiter) ||
@@ -179,23 +1712,535 @@ var require_core = __commonJS({
           step((generator = generator.apply(thisArg, _arguments || [])).next());
         });
       };
+    Object.defineProperty(exports2, '__esModule', { value: true });
+    exports2.PersonalAccessTokenCredentialHandler =
+      exports2.BearerCredentialHandler =
+      exports2.BasicCredentialHandler =
+        void 0;
+    var BasicCredentialHandler = class {
+      constructor(username, password) {
+        this.username = username;
+        this.password = password;
+      }
+      prepareRequest(options) {
+        if (!options.headers) {
+          throw Error('The request has no headers');
+        }
+        options.headers['Authorization'] = `Basic ${Buffer.from(
+          `${this.username}:${this.password}`
+        ).toString('base64')}`;
+      }
+      canHandleAuthentication() {
+        return false;
+      }
+      handleAuthentication() {
+        return __awaiter(this, void 0, void 0, function* () {
+          throw new Error('not implemented');
+        });
+      }
+    };
+    exports2.BasicCredentialHandler = BasicCredentialHandler;
+    var BearerCredentialHandler = class {
+      constructor(token) {
+        this.token = token;
+      }
+      prepareRequest(options) {
+        if (!options.headers) {
+          throw Error('The request has no headers');
+        }
+        options.headers['Authorization'] = `Bearer ${this.token}`;
+      }
+      canHandleAuthentication() {
+        return false;
+      }
+      handleAuthentication() {
+        return __awaiter(this, void 0, void 0, function* () {
+          throw new Error('not implemented');
+        });
+      }
+    };
+    exports2.BearerCredentialHandler = BearerCredentialHandler;
+    var PersonalAccessTokenCredentialHandler = class {
+      constructor(token) {
+        this.token = token;
+      }
+      prepareRequest(options) {
+        if (!options.headers) {
+          throw Error('The request has no headers');
+        }
+        options.headers['Authorization'] = `Basic ${Buffer.from(`PAT:${this.token}`).toString(
+          'base64'
+        )}`;
+      }
+      canHandleAuthentication() {
+        return false;
+      }
+      handleAuthentication() {
+        return __awaiter(this, void 0, void 0, function* () {
+          throw new Error('not implemented');
+        });
+      }
+    };
+    exports2.PersonalAccessTokenCredentialHandler = PersonalAccessTokenCredentialHandler;
+  }
+});
+
+// node_modules/@actions/core/lib/oidc-utils.js
+var require_oidc_utils = __commonJS({
+  'node_modules/@actions/core/lib/oidc-utils.js'(exports2) {
+    'use strict';
+    var __awaiter =
+      (exports2 && exports2.__awaiter) ||
+      function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+          return value instanceof P
+            ? value
+            : new P(function (resolve) {
+                resolve(value);
+              });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+          function fulfilled(value) {
+            try {
+              step(generator.next(value));
+            } catch (e) {
+              reject(e);
+            }
+          }
+          function rejected(value) {
+            try {
+              step(generator['throw'](value));
+            } catch (e) {
+              reject(e);
+            }
+          }
+          function step(result) {
+            result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+          }
+          step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+      };
+    Object.defineProperty(exports2, '__esModule', { value: true });
+    exports2.OidcClient = void 0;
+    var http_client_1 = require_lib();
+    var auth_1 = require_auth();
+    var core_1 = require_core();
+    var OidcClient = class {
+      static createHttpClient(allowRetry = true, maxRetry = 10) {
+        const requestOptions = {
+          allowRetries: allowRetry,
+          maxRetries: maxRetry
+        };
+        return new http_client_1.HttpClient(
+          'actions/oidc-client',
+          [new auth_1.BearerCredentialHandler(OidcClient.getRequestToken())],
+          requestOptions
+        );
+      }
+      static getRequestToken() {
+        const token = process.env['ACTIONS_ID_TOKEN_REQUEST_TOKEN'];
+        if (!token) {
+          throw new Error('Unable to get ACTIONS_ID_TOKEN_REQUEST_TOKEN env variable');
+        }
+        return token;
+      }
+      static getIDTokenUrl() {
+        const runtimeUrl = process.env['ACTIONS_ID_TOKEN_REQUEST_URL'];
+        if (!runtimeUrl) {
+          throw new Error('Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable');
+        }
+        return runtimeUrl;
+      }
+      static getCall(id_token_url) {
+        var _a;
+        return __awaiter(this, void 0, void 0, function* () {
+          const httpclient = OidcClient.createHttpClient();
+          const res = yield httpclient.getJson(id_token_url).catch(error => {
+            throw new Error(`Failed to get ID Token. 
+ 
+        Error Code : ${error.statusCode}
+ 
+        Error Message: ${error.result.message}`);
+          });
+          const id_token = (_a = res.result) === null || _a === void 0 ? void 0 : _a.value;
+          if (!id_token) {
+            throw new Error('Response json body do not have ID Token field');
+          }
+          return id_token;
+        });
+      }
+      static getIDToken(audience) {
+        return __awaiter(this, void 0, void 0, function* () {
+          try {
+            let id_token_url = OidcClient.getIDTokenUrl();
+            if (audience) {
+              const encodedAudience = encodeURIComponent(audience);
+              id_token_url = `${id_token_url}&audience=${encodedAudience}`;
+            }
+            core_1.debug(`ID token url is ${id_token_url}`);
+            const id_token = yield OidcClient.getCall(id_token_url);
+            core_1.setSecret(id_token);
+            return id_token;
+          } catch (error) {
+            throw new Error(`Error message: ${error.message}`);
+          }
+        });
+      }
+    };
+    exports2.OidcClient = OidcClient;
+  }
+});
+
+// node_modules/@actions/core/lib/summary.js
+var require_summary = __commonJS({
+  'node_modules/@actions/core/lib/summary.js'(exports2) {
+    'use strict';
+    var __awaiter =
+      (exports2 && exports2.__awaiter) ||
+      function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+          return value instanceof P
+            ? value
+            : new P(function (resolve) {
+                resolve(value);
+              });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+          function fulfilled(value) {
+            try {
+              step(generator.next(value));
+            } catch (e) {
+              reject(e);
+            }
+          }
+          function rejected(value) {
+            try {
+              step(generator['throw'](value));
+            } catch (e) {
+              reject(e);
+            }
+          }
+          function step(result) {
+            result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+          }
+          step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+      };
+    Object.defineProperty(exports2, '__esModule', { value: true });
+    exports2.summary =
+      exports2.markdownSummary =
+      exports2.SUMMARY_DOCS_URL =
+      exports2.SUMMARY_ENV_VAR =
+        void 0;
+    var os_1 = require('os');
+    var fs_1 = require('fs');
+    var { access, appendFile, writeFile } = fs_1.promises;
+    exports2.SUMMARY_ENV_VAR = 'GITHUB_STEP_SUMMARY';
+    exports2.SUMMARY_DOCS_URL =
+      'https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary';
+    var Summary = class {
+      constructor() {
+        this._buffer = '';
+      }
+      filePath() {
+        return __awaiter(this, void 0, void 0, function* () {
+          if (this._filePath) {
+            return this._filePath;
+          }
+          const pathFromEnv = process.env[exports2.SUMMARY_ENV_VAR];
+          if (!pathFromEnv) {
+            throw new Error(
+              `Unable to find environment variable for $${exports2.SUMMARY_ENV_VAR}. Check if your runtime environment supports job summaries.`
+            );
+          }
+          try {
+            yield access(pathFromEnv, fs_1.constants.R_OK | fs_1.constants.W_OK);
+          } catch (_a) {
+            throw new Error(
+              `Unable to access summary file: '${pathFromEnv}'. Check if the file has correct read/write permissions.`
+            );
+          }
+          this._filePath = pathFromEnv;
+          return this._filePath;
+        });
+      }
+      wrap(tag, content, attrs = {}) {
+        const htmlAttrs = Object.entries(attrs)
+          .map(([key, value]) => ` ${key}="${value}"`)
+          .join('');
+        if (!content) {
+          return `<${tag}${htmlAttrs}>`;
+        }
+        return `<${tag}${htmlAttrs}>${content}</${tag}>`;
+      }
+      write(options) {
+        return __awaiter(this, void 0, void 0, function* () {
+          const overwrite = !!(options === null || options === void 0 ? void 0 : options.overwrite);
+          const filePath = yield this.filePath();
+          const writeFunc = overwrite ? writeFile : appendFile;
+          yield writeFunc(filePath, this._buffer, { encoding: 'utf8' });
+          return this.emptyBuffer();
+        });
+      }
+      clear() {
+        return __awaiter(this, void 0, void 0, function* () {
+          return this.emptyBuffer().write({ overwrite: true });
+        });
+      }
+      stringify() {
+        return this._buffer;
+      }
+      isEmptyBuffer() {
+        return this._buffer.length === 0;
+      }
+      emptyBuffer() {
+        this._buffer = '';
+        return this;
+      }
+      addRaw(text, addEOL = false) {
+        this._buffer += text;
+        return addEOL ? this.addEOL() : this;
+      }
+      addEOL() {
+        return this.addRaw(os_1.EOL);
+      }
+      addCodeBlock(code, lang) {
+        const attrs = Object.assign({}, lang && { lang });
+        const element = this.wrap('pre', this.wrap('code', code), attrs);
+        return this.addRaw(element).addEOL();
+      }
+      addList(items, ordered = false) {
+        const tag = ordered ? 'ol' : 'ul';
+        const listItems = items.map(item => this.wrap('li', item)).join('');
+        const element = this.wrap(tag, listItems);
+        return this.addRaw(element).addEOL();
+      }
+      addTable(rows) {
+        const tableBody = rows
+          .map(row => {
+            const cells = row
+              .map(cell => {
+                if (typeof cell === 'string') {
+                  return this.wrap('td', cell);
+                }
+                const { header, data, colspan, rowspan } = cell;
+                const tag = header ? 'th' : 'td';
+                const attrs = Object.assign(
+                  Object.assign({}, colspan && { colspan }),
+                  rowspan && { rowspan }
+                );
+                return this.wrap(tag, data, attrs);
+              })
+              .join('');
+            return this.wrap('tr', cells);
+          })
+          .join('');
+        const element = this.wrap('table', tableBody);
+        return this.addRaw(element).addEOL();
+      }
+      addDetails(label, content) {
+        const element = this.wrap('details', this.wrap('summary', label) + content);
+        return this.addRaw(element).addEOL();
+      }
+      addImage(src, alt, options) {
+        const { width, height } = options || {};
+        const attrs = Object.assign(Object.assign({}, width && { width }), height && { height });
+        const element = this.wrap('img', null, Object.assign({ src, alt }, attrs));
+        return this.addRaw(element).addEOL();
+      }
+      addHeading(text, level) {
+        const tag = `h${level}`;
+        const allowedTag = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'].includes(tag) ? tag : 'h1';
+        const element = this.wrap(allowedTag, text);
+        return this.addRaw(element).addEOL();
+      }
+      addSeparator() {
+        const element = this.wrap('hr', null);
+        return this.addRaw(element).addEOL();
+      }
+      addBreak() {
+        const element = this.wrap('br', null);
+        return this.addRaw(element).addEOL();
+      }
+      addQuote(text, cite) {
+        const attrs = Object.assign({}, cite && { cite });
+        const element = this.wrap('blockquote', text, attrs);
+        return this.addRaw(element).addEOL();
+      }
+      addLink(text, href) {
+        const element = this.wrap('a', text, { href });
+        return this.addRaw(element).addEOL();
+      }
+    };
+    var _summary = new Summary();
+    exports2.markdownSummary = _summary;
+    exports2.summary = _summary;
+  }
+});
+
+// node_modules/@actions/core/lib/path-utils.js
+var require_path_utils = __commonJS({
+  'node_modules/@actions/core/lib/path-utils.js'(exports2) {
+    'use strict';
+    var __createBinding =
+      (exports2 && exports2.__createBinding) ||
+      (Object.create
+        ? function (o, m, k, k2) {
+            if (k2 === void 0) k2 = k;
+            Object.defineProperty(o, k2, {
+              enumerable: true,
+              get: function () {
+                return m[k];
+              }
+            });
+          }
+        : function (o, m, k, k2) {
+            if (k2 === void 0) k2 = k;
+            o[k2] = m[k];
+          });
+    var __setModuleDefault =
+      (exports2 && exports2.__setModuleDefault) ||
+      (Object.create
+        ? function (o, v) {
+            Object.defineProperty(o, 'default', { enumerable: true, value: v });
+          }
+        : function (o, v) {
+            o['default'] = v;
+          });
     var __importStar =
       (exports2 && exports2.__importStar) ||
       function (mod) {
         if (mod && mod.__esModule) return mod;
         var result = {};
         if (mod != null) {
-          for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
+          for (var k in mod)
+            if (k !== 'default' && Object.hasOwnProperty.call(mod, k))
+              __createBinding(result, mod, k);
         }
-        result['default'] = mod;
+        __setModuleDefault(result, mod);
         return result;
       };
     Object.defineProperty(exports2, '__esModule', { value: true });
+    exports2.toPlatformPath = exports2.toWin32Path = exports2.toPosixPath = void 0;
+    var path2 = __importStar(require('path'));
+    function toPosixPath(pth) {
+      return pth.replace(/[\\]/g, '/');
+    }
+    exports2.toPosixPath = toPosixPath;
+    function toWin32Path(pth) {
+      return pth.replace(/[/]/g, '\\');
+    }
+    exports2.toWin32Path = toWin32Path;
+    function toPlatformPath(pth) {
+      return pth.replace(/[/\\]/g, path2.sep);
+    }
+    exports2.toPlatformPath = toPlatformPath;
+  }
+});
+
+// node_modules/@actions/core/lib/core.js
+var require_core = __commonJS({
+  'node_modules/@actions/core/lib/core.js'(exports2) {
+    'use strict';
+    var __createBinding =
+      (exports2 && exports2.__createBinding) ||
+      (Object.create
+        ? function (o, m, k, k2) {
+            if (k2 === void 0) k2 = k;
+            Object.defineProperty(o, k2, {
+              enumerable: true,
+              get: function () {
+                return m[k];
+              }
+            });
+          }
+        : function (o, m, k, k2) {
+            if (k2 === void 0) k2 = k;
+            o[k2] = m[k];
+          });
+    var __setModuleDefault =
+      (exports2 && exports2.__setModuleDefault) ||
+      (Object.create
+        ? function (o, v) {
+            Object.defineProperty(o, 'default', { enumerable: true, value: v });
+          }
+        : function (o, v) {
+            o['default'] = v;
+          });
+    var __importStar =
+      (exports2 && exports2.__importStar) ||
+      function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) {
+          for (var k in mod)
+            if (k !== 'default' && Object.hasOwnProperty.call(mod, k))
+              __createBinding(result, mod, k);
+        }
+        __setModuleDefault(result, mod);
+        return result;
+      };
+    var __awaiter =
+      (exports2 && exports2.__awaiter) ||
+      function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+          return value instanceof P
+            ? value
+            : new P(function (resolve) {
+                resolve(value);
+              });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+          function fulfilled(value) {
+            try {
+              step(generator.next(value));
+            } catch (e) {
+              reject(e);
+            }
+          }
+          function rejected(value) {
+            try {
+              step(generator['throw'](value));
+            } catch (e) {
+              reject(e);
+            }
+          }
+          function step(result) {
+            result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+          }
+          step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+      };
+    Object.defineProperty(exports2, '__esModule', { value: true });
+    exports2.getIDToken =
+      exports2.getState =
+      exports2.saveState =
+      exports2.group =
+      exports2.endGroup =
+      exports2.startGroup =
+      exports2.info =
+      exports2.notice =
+      exports2.warning =
+      exports2.error =
+      exports2.debug =
+      exports2.isDebug =
+      exports2.setFailed =
+      exports2.setCommandEcho =
+      exports2.setOutput =
+      exports2.getBooleanInput =
+      exports2.getMultilineInput =
+      exports2.getInput =
+      exports2.addPath =
+      exports2.setSecret =
+      exports2.exportVariable =
+      exports2.ExitCode =
+        void 0;
     var command_1 = require_command();
     var file_command_1 = require_file_command();
     var utils_1 = require_utils();
     var os3 = __importStar(require('os'));
     var path2 = __importStar(require('path'));
+    var oidc_utils_1 = require_oidc_utils();
     var ExitCode;
     (function (ExitCode2) {
       ExitCode2[(ExitCode2['Success'] = 0)] = 'Success';
@@ -206,12 +2251,12 @@ var require_core = __commonJS({
       process.env[name] = convertedVal;
       const filePath = process.env['GITHUB_ENV'] || '';
       if (filePath) {
-        const delimiter = '_GitHubActionsFileCommandDelimeter_';
-        const commandValue = `${name}<<${delimiter}${os3.EOL}${convertedVal}${os3.EOL}${delimiter}`;
-        file_command_1.issueCommand('ENV', commandValue);
-      } else {
-        command_1.issueCommand('set-env', { name }, convertedVal);
+        return file_command_1.issueFileCommand(
+          'ENV',
+          file_command_1.prepareKeyValueMessage(name, val)
+        );
       }
+      command_1.issueCommand('set-env', { name }, convertedVal);
     }
     exports2.exportVariable = exportVariable;
     function setSecret(secret) {
@@ -221,7 +2266,7 @@ var require_core = __commonJS({
     function addPath(inputPath) {
       const filePath = process.env['GITHUB_PATH'] || '';
       if (filePath) {
-        file_command_1.issueCommand('PATH', inputPath);
+        file_command_1.issueFileCommand('PATH', inputPath);
       } else {
         command_1.issueCommand('add-path', {}, inputPath);
       }
@@ -233,12 +2278,42 @@ var require_core = __commonJS({
       if (options && options.required && !val) {
         throw new Error(`Input required and not supplied: ${name}`);
       }
+      if (options && options.trimWhitespace === false) {
+        return val;
+      }
       return val.trim();
     }
     exports2.getInput = getInput;
+    function getMultilineInput(name, options) {
+      const inputs = getInput(name, options)
+        .split('\n')
+        .filter(x => x !== '');
+      if (options && options.trimWhitespace === false) {
+        return inputs;
+      }
+      return inputs.map(input => input.trim());
+    }
+    exports2.getMultilineInput = getMultilineInput;
+    function getBooleanInput(name, options) {
+      const trueValue = ['true', 'True', 'TRUE'];
+      const falseValue = ['false', 'False', 'FALSE'];
+      const val = getInput(name, options);
+      if (trueValue.includes(val)) return true;
+      if (falseValue.includes(val)) return false;
+      throw new TypeError(`Input does not meet YAML 1.2 "Core Schema" specification: ${name}
+Support boolean input list: \`true | True | TRUE | false | False | FALSE\``);
+    }
+    exports2.getBooleanInput = getBooleanInput;
     function setOutput(name, value) {
+      const filePath = process.env['GITHUB_OUTPUT'] || '';
+      if (filePath) {
+        return file_command_1.issueFileCommand(
+          'OUTPUT',
+          file_command_1.prepareKeyValueMessage(name, value)
+        );
+      }
       process.stdout.write(os3.EOL);
-      command_1.issueCommand('set-output', { name }, value);
+      command_1.issueCommand('set-output', { name }, utils_1.toCommandValue(value));
     }
     exports2.setOutput = setOutput;
     function setCommandEcho(enabled) {
@@ -258,14 +2333,30 @@ var require_core = __commonJS({
       command_1.issueCommand('debug', {}, message);
     }
     exports2.debug = debug;
-    function error(message) {
-      command_1.issue('error', message instanceof Error ? message.toString() : message);
+    function error(message, properties = {}) {
+      command_1.issueCommand(
+        'error',
+        utils_1.toCommandProperties(properties),
+        message instanceof Error ? message.toString() : message
+      );
     }
     exports2.error = error;
-    function warning(message) {
-      command_1.issue('warning', message instanceof Error ? message.toString() : message);
+    function warning(message, properties = {}) {
+      command_1.issueCommand(
+        'warning',
+        utils_1.toCommandProperties(properties),
+        message instanceof Error ? message.toString() : message
+      );
     }
     exports2.warning = warning;
+    function notice(message, properties = {}) {
+      command_1.issueCommand(
+        'notice',
+        utils_1.toCommandProperties(properties),
+        message instanceof Error ? message.toString() : message
+      );
+    }
+    exports2.notice = notice;
     function info(message) {
       process.stdout.write(message + os3.EOL);
     }
@@ -292,13 +2383,59 @@ var require_core = __commonJS({
     }
     exports2.group = group;
     function saveState(name, value) {
-      command_1.issueCommand('save-state', { name }, value);
+      const filePath = process.env['GITHUB_STATE'] || '';
+      if (filePath) {
+        return file_command_1.issueFileCommand(
+          'STATE',
+          file_command_1.prepareKeyValueMessage(name, value)
+        );
+      }
+      command_1.issueCommand('save-state', { name }, utils_1.toCommandValue(value));
     }
     exports2.saveState = saveState;
     function getState(name) {
       return process.env[`STATE_${name}`] || '';
     }
     exports2.getState = getState;
+    function getIDToken(aud) {
+      return __awaiter(this, void 0, void 0, function* () {
+        return yield oidc_utils_1.OidcClient.getIDToken(aud);
+      });
+    }
+    exports2.getIDToken = getIDToken;
+    var summary_1 = require_summary();
+    Object.defineProperty(exports2, 'summary', {
+      enumerable: true,
+      get: function () {
+        return summary_1.summary;
+      }
+    });
+    var summary_2 = require_summary();
+    Object.defineProperty(exports2, 'markdownSummary', {
+      enumerable: true,
+      get: function () {
+        return summary_2.markdownSummary;
+      }
+    });
+    var path_utils_1 = require_path_utils();
+    Object.defineProperty(exports2, 'toPosixPath', {
+      enumerable: true,
+      get: function () {
+        return path_utils_1.toPosixPath;
+      }
+    });
+    Object.defineProperty(exports2, 'toWin32Path', {
+      enumerable: true,
+      get: function () {
+        return path_utils_1.toWin32Path;
+      }
+    });
+    Object.defineProperty(exports2, 'toPlatformPath', {
+      enumerable: true,
+      get: function () {
+        return path_utils_1.toPlatformPath;
+      }
+    });
   }
 });
 
@@ -2244,7 +4381,7 @@ var require_manifest = __commonJS({
 });
 
 // node_modules/@actions/http-client/proxy.js
-var require_proxy = __commonJS({
+var require_proxy2 = __commonJS({
   'node_modules/@actions/http-client/proxy.js'(exports2) {
     'use strict';
     Object.defineProperty(exports2, '__esModule', { value: true });
@@ -2300,242 +4437,6 @@ var require_proxy = __commonJS({
   }
 });
 
-// node_modules/tunnel/lib/tunnel.js
-var require_tunnel = __commonJS({
-  'node_modules/tunnel/lib/tunnel.js'(exports2) {
-    'use strict';
-    var net = require('net');
-    var tls = require('tls');
-    var http = require('http');
-    var https = require('https');
-    var events = require('events');
-    var assert = require('assert');
-    var util = require('util');
-    exports2.httpOverHttp = httpOverHttp;
-    exports2.httpsOverHttp = httpsOverHttp;
-    exports2.httpOverHttps = httpOverHttps;
-    exports2.httpsOverHttps = httpsOverHttps;
-    function httpOverHttp(options) {
-      var agent = new TunnelingAgent(options);
-      agent.request = http.request;
-      return agent;
-    }
-    function httpsOverHttp(options) {
-      var agent = new TunnelingAgent(options);
-      agent.request = http.request;
-      agent.createSocket = createSecureSocket;
-      agent.defaultPort = 443;
-      return agent;
-    }
-    function httpOverHttps(options) {
-      var agent = new TunnelingAgent(options);
-      agent.request = https.request;
-      return agent;
-    }
-    function httpsOverHttps(options) {
-      var agent = new TunnelingAgent(options);
-      agent.request = https.request;
-      agent.createSocket = createSecureSocket;
-      agent.defaultPort = 443;
-      return agent;
-    }
-    function TunnelingAgent(options) {
-      var self = this;
-      self.options = options || {};
-      self.proxyOptions = self.options.proxy || {};
-      self.maxSockets = self.options.maxSockets || http.Agent.defaultMaxSockets;
-      self.requests = [];
-      self.sockets = [];
-      self.on('free', function onFree(socket, host, port, localAddress) {
-        var options2 = toOptions(host, port, localAddress);
-        for (var i = 0, len = self.requests.length; i < len; ++i) {
-          var pending = self.requests[i];
-          if (pending.host === options2.host && pending.port === options2.port) {
-            self.requests.splice(i, 1);
-            pending.request.onSocket(socket);
-            return;
-          }
-        }
-        socket.destroy();
-        self.removeSocket(socket);
-      });
-    }
-    util.inherits(TunnelingAgent, events.EventEmitter);
-    TunnelingAgent.prototype.addRequest = function addRequest(req, host, port, localAddress) {
-      var self = this;
-      var options = mergeOptions(
-        { request: req },
-        self.options,
-        toOptions(host, port, localAddress)
-      );
-      if (self.sockets.length >= this.maxSockets) {
-        self.requests.push(options);
-        return;
-      }
-      self.createSocket(options, function (socket) {
-        socket.on('free', onFree);
-        socket.on('close', onCloseOrRemove);
-        socket.on('agentRemove', onCloseOrRemove);
-        req.onSocket(socket);
-        function onFree() {
-          self.emit('free', socket, options);
-        }
-        function onCloseOrRemove(err) {
-          self.removeSocket(socket);
-          socket.removeListener('free', onFree);
-          socket.removeListener('close', onCloseOrRemove);
-          socket.removeListener('agentRemove', onCloseOrRemove);
-        }
-      });
-    };
-    TunnelingAgent.prototype.createSocket = function createSocket(options, cb) {
-      var self = this;
-      var placeholder = {};
-      self.sockets.push(placeholder);
-      var connectOptions = mergeOptions({}, self.proxyOptions, {
-        method: 'CONNECT',
-        path: options.host + ':' + options.port,
-        agent: false,
-        headers: {
-          host: options.host + ':' + options.port
-        }
-      });
-      if (options.localAddress) {
-        connectOptions.localAddress = options.localAddress;
-      }
-      if (connectOptions.proxyAuth) {
-        connectOptions.headers = connectOptions.headers || {};
-        connectOptions.headers['Proxy-Authorization'] =
-          'Basic ' + new Buffer(connectOptions.proxyAuth).toString('base64');
-      }
-      debug('making CONNECT request');
-      var connectReq = self.request(connectOptions);
-      connectReq.useChunkedEncodingByDefault = false;
-      connectReq.once('response', onResponse);
-      connectReq.once('upgrade', onUpgrade);
-      connectReq.once('connect', onConnect);
-      connectReq.once('error', onError);
-      connectReq.end();
-      function onResponse(res) {
-        res.upgrade = true;
-      }
-      function onUpgrade(res, socket, head) {
-        process.nextTick(function () {
-          onConnect(res, socket, head);
-        });
-      }
-      function onConnect(res, socket, head) {
-        connectReq.removeAllListeners();
-        socket.removeAllListeners();
-        if (res.statusCode !== 200) {
-          debug('tunneling socket could not be established, statusCode=%d', res.statusCode);
-          socket.destroy();
-          var error = new Error(
-            'tunneling socket could not be established, statusCode=' + res.statusCode
-          );
-          error.code = 'ECONNRESET';
-          options.request.emit('error', error);
-          self.removeSocket(placeholder);
-          return;
-        }
-        if (head.length > 0) {
-          debug('got illegal response body from proxy');
-          socket.destroy();
-          var error = new Error('got illegal response body from proxy');
-          error.code = 'ECONNRESET';
-          options.request.emit('error', error);
-          self.removeSocket(placeholder);
-          return;
-        }
-        debug('tunneling connection has established');
-        self.sockets[self.sockets.indexOf(placeholder)] = socket;
-        return cb(socket);
-      }
-      function onError(cause) {
-        connectReq.removeAllListeners();
-        debug('tunneling socket could not be established, cause=%s\n', cause.message, cause.stack);
-        var error = new Error('tunneling socket could not be established, cause=' + cause.message);
-        error.code = 'ECONNRESET';
-        options.request.emit('error', error);
-        self.removeSocket(placeholder);
-      }
-    };
-    TunnelingAgent.prototype.removeSocket = function removeSocket(socket) {
-      var pos = this.sockets.indexOf(socket);
-      if (pos === -1) {
-        return;
-      }
-      this.sockets.splice(pos, 1);
-      var pending = this.requests.shift();
-      if (pending) {
-        this.createSocket(pending, function (socket2) {
-          pending.request.onSocket(socket2);
-        });
-      }
-    };
-    function createSecureSocket(options, cb) {
-      var self = this;
-      TunnelingAgent.prototype.createSocket.call(self, options, function (socket) {
-        var hostHeader = options.request.getHeader('host');
-        var tlsOptions = mergeOptions({}, self.options, {
-          socket,
-          servername: hostHeader ? hostHeader.replace(/:.*$/, '') : options.host
-        });
-        var secureSocket = tls.connect(0, tlsOptions);
-        self.sockets[self.sockets.indexOf(socket)] = secureSocket;
-        cb(secureSocket);
-      });
-    }
-    function toOptions(host, port, localAddress) {
-      if (typeof host === 'string') {
-        return {
-          host,
-          port,
-          localAddress
-        };
-      }
-      return host;
-    }
-    function mergeOptions(target) {
-      for (var i = 1, len = arguments.length; i < len; ++i) {
-        var overrides = arguments[i];
-        if (typeof overrides === 'object') {
-          var keys = Object.keys(overrides);
-          for (var j = 0, keyLen = keys.length; j < keyLen; ++j) {
-            var k = keys[j];
-            if (overrides[k] !== void 0) {
-              target[k] = overrides[k];
-            }
-          }
-        }
-      }
-      return target;
-    }
-    var debug;
-    if (process.env.NODE_DEBUG && /\btunnel\b/.test(process.env.NODE_DEBUG)) {
-      debug = function () {
-        var args = Array.prototype.slice.call(arguments);
-        if (typeof args[0] === 'string') {
-          args[0] = 'TUNNEL: ' + args[0];
-        } else {
-          args.unshift('TUNNEL:');
-        }
-        console.error.apply(console, args);
-      };
-    } else {
-      debug = function () {};
-    }
-    exports2.debug = debug;
-  }
-});
-
-// node_modules/tunnel/index.js
-var require_tunnel2 = __commonJS({
-  'node_modules/tunnel/index.js'(exports2, module2) {
-    module2.exports = require_tunnel();
-  }
-});
-
 // node_modules/@actions/http-client/index.js
 var require_http_client = __commonJS({
   'node_modules/@actions/http-client/index.js'(exports2) {
@@ -2543,7 +4444,7 @@ var require_http_client = __commonJS({
     Object.defineProperty(exports2, '__esModule', { value: true });
     var http = require('http');
     var https = require('https');
-    var pm = require_proxy();
+    var pm = require_proxy2();
     var tunnel;
     var HttpCodes;
     (function (HttpCodes2) {
@@ -3049,7 +4950,7 @@ var require_http_client = __commonJS({
 });
 
 // node_modules/uuid/lib/rng.js
-var require_rng = __commonJS({
+var require_rng2 = __commonJS({
   'node_modules/uuid/lib/rng.js'(exports2, module2) {
     var crypto = require('crypto');
     module2.exports = function nodeRNG() {
@@ -3096,9 +4997,9 @@ var require_bytesToUuid = __commonJS({
 });
 
 // node_modules/uuid/v4.js
-var require_v4 = __commonJS({
+var require_v42 = __commonJS({
   'node_modules/uuid/v4.js'(exports2, module2) {
-    var rng = require_rng();
+    var rng = require_rng2();
     var bytesToUuid = require_bytesToUuid();
     function v4(options, buf, offset) {
       var i = (buf && offset) || 0;
@@ -4012,7 +5913,7 @@ var require_tool_cache = __commonJS({
     var semver = __importStar(require_semver());
     var stream = __importStar(require('stream'));
     var util = __importStar(require('util'));
-    var v4_1 = __importDefault(require_v4());
+    var v4_1 = __importDefault(require_v42());
     var exec_1 = require_exec();
     var assert_1 = require('assert');
     var retry_helper_1 = require_retry_helper();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,670 @@
 {
   "name": "setup-flyway",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "setup-flyway",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@actions/core": "^1.10.0",
+        "@actions/tool-cache": "^1.7.1"
+      },
+      "devDependencies": {
+        "esbuild": "^0.12.8",
+        "husky": "^4.3.8",
+        "install": "^0.13.0",
+        "prettier": "^2.3.0"
+      }
+    },
+    "node_modules/@actions/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-2aZDDa3zrrZbP5ZYg159sNoLRb61nQ7awl5pSvIq5Qpj81vwDzdMRKzkWJGJuwVvWpvZKx7vspJALyvaaIQyug==",
+      "dependencies": {
+        "@actions/http-client": "^2.0.1",
+        "uuid": "^8.3.2"
+      }
+    },
+    "node_modules/@actions/core/node_modules/@actions/http-client": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.0.1.tgz",
+      "integrity": "sha512-PIXiMVtz6VvyaRsGY268qvj57hXQEpsYogYOu2nrQhlf+XCGmZstmuZBbAybUl1nQGnvS1k1eEsQ69ZoD7xlSw==",
+      "dependencies": {
+        "tunnel": "^0.0.6"
+      }
+    },
+    "node_modules/@actions/core/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@actions/exec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.1.0.tgz",
+      "integrity": "sha512-LImpN9AY0J1R1mEYJjVJfSZWU4zYOlEcwSTgPve1rFQqK5AwrEs6uWW5Rv70gbDIQIAUwI86z6B+9mPK4w9Sbg==",
+      "dependencies": {
+        "@actions/io": "^1.0.1"
+      }
+    },
+    "node_modules/@actions/http-client": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-1.0.11.tgz",
+      "integrity": "sha512-VRYHGQV1rqnROJqdMvGUbY/Kn8vriQe/F9HR2AlYHzmKuM/p3kjNuXhmdBfcVgsvRWTz5C5XW5xvndZrVBuAYg==",
+      "dependencies": {
+        "tunnel": "0.0.6"
+      }
+    },
+    "node_modules/@actions/io": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.1.tgz",
+      "integrity": "sha512-Qi4JoKXjmE0O67wAOH6y0n26QXhMKMFo7GD/4IXNVcrtLjUlGjGuVys6pQgwF3ArfGTQu0XpqaNr0YhED2RaRA=="
+    },
+    "node_modules/@actions/tool-cache": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@actions/tool-cache/-/tool-cache-1.7.1.tgz",
+      "integrity": "sha512-y1xxxOhXaBUIUit3lhepmu/0xdgiTMpnZRLmVdtF0hTm521doi+MdRRRP62czHvM7wxH6epj4JPNJQ3iJpOrkQ==",
+      "dependencies": {
+        "@actions/core": "^1.2.6",
+        "@actions/exec": "^1.0.0",
+        "@actions/http-client": "^1.0.8",
+        "@actions/io": "^1.1.1",
+        "semver": "^6.1.0",
+        "uuid": "^3.3.2"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+      "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/highlight": "^7.12.13"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.0.tgz",
+      "integrity": "sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A==",
+      "dev": true
+    },
+    "node_modules/@babel/highlight": {
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.0.tgz",
+      "integrity": "sha512-YSCOwxvTYEIMSGaBQb5kDDsCopDdiUGsqpatp3fOlI4+2HQSkTmEVWnVuySdAC5EWCqSWWTv0ib63RjR7dTBdg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.14.0",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "node_modules/@babel/highlight/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@types/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
+      "dev": true
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/ci-info": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+      "dev": true
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/compare-versions": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.6.0.tgz",
+      "integrity": "sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA==",
+      "dev": true
+    },
+    "node_modules/cosmiconfig": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.0.tgz",
+      "integrity": "sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==",
+      "dev": true,
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.12.8",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.8.tgz",
+      "integrity": "sha512-sx/LwlP/SWTGsd9G4RlOPrXnIihAJ2xwBUmzoqe2nWwbXORMQWtAGNJNYLBJJqa3e9PWvVzxdrtyFZJcr7D87g==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/find-versions": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-4.0.0.tgz",
+      "integrity": "sha512-wgpWy002tA+wgmO27buH/9KzyEOQnKsG/R0yrcjPT9BOFm0zRBVQbZ95nRGXWMywS8YR5knRbpohio0bcJABxQ==",
+      "dev": true,
+      "dependencies": {
+        "semver-regex": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/husky": {
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-4.3.8.tgz",
+      "integrity": "sha512-LCqqsB0PzJQ/AlCgfrfzRe3e3+NvmefAdKQhRYpxS4u6clblBoDdzzvHi8fmxKRzvMxPY/1WZWzomPZww0Anow==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "ci-info": "^2.0.0",
+        "compare-versions": "^3.6.0",
+        "cosmiconfig": "^7.0.0",
+        "find-versions": "^4.0.0",
+        "opencollective-postinstall": "^2.0.2",
+        "pkg-dir": "^5.0.0",
+        "please-upgrade-node": "^3.2.0",
+        "slash": "^3.0.0",
+        "which-pm-runs": "^1.0.0"
+      },
+      "bin": {
+        "husky-run": "bin/run.js",
+        "husky-upgrade": "lib/upgrader/bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/husky"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "dev": true,
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/install": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/install/-/install-0.13.0.tgz",
+      "integrity": "sha512-zDml/jzr2PKU9I8J/xyZBQn8rPCAY//UOYNmR01XwNwyfhEWObo2SWfSl1+0tm1u6PhxLwDnfsT/6jB7OUxqFA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
+      "dev": true
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/opencollective-postinstall": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
+      "integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==",
+      "dev": true,
+      "bin": {
+        "opencollective-postinstall": "index.js"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
+      "integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/please-upgrade-node": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
+      "integrity": "sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==",
+      "dev": true,
+      "dependencies": {
+        "semver-compare": "^1.0.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.0.tgz",
+      "integrity": "sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
+      "dev": true
+    },
+    "node_modules/semver-regex": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.4.tgz",
+      "integrity": "sha512-6IiqeZNgq01qGf0TId0t3NvKzSvUsjcpdEO3AQNeIjR6A2+ckTnQlDpl4qu1bjRv0RzN3FP9hzFmws3lKqRWkA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
+    "node_modules/which-pm-runs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
+      "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=",
+      "dev": true
+    },
+    "node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  },
   "dependencies": {
     "@actions/core": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.7.tgz",
-      "integrity": "sha512-kzLFD5BgEvq6ubcxdgPbRKGD2Qrgya/5j+wh4LZzqT915I0V3rED+MvjH6NXghbvk1MXknpNNQ3uKjXSEN00Ig=="
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-2aZDDa3zrrZbP5ZYg159sNoLRb61nQ7awl5pSvIq5Qpj81vwDzdMRKzkWJGJuwVvWpvZKx7vspJALyvaaIQyug==",
+      "requires": {
+        "@actions/http-client": "^2.0.1",
+        "uuid": "^8.3.2"
+      },
+      "dependencies": {
+        "@actions/http-client": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.0.1.tgz",
+          "integrity": "sha512-PIXiMVtz6VvyaRsGY268qvj57hXQEpsYogYOu2nrQhlf+XCGmZstmuZBbAybUl1nQGnvS1k1eEsQ69ZoD7xlSw==",
+          "requires": {
+            "tunnel": "^0.0.6"
+          }
+        },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+        }
+      }
     },
     "@actions/exec": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": "wtw",
   "license": "ISC",
   "dependencies": {
-    "@actions/core": "^1.2.7",
+    "@actions/core": "^1.10.0",
     "@actions/tool-cache": "^1.7.1"
   },
   "devDependencies": {


### PR DESCRIPTION
# Summary of PR changes

- Only include certain files when considering when to increment the tag.
- Remove the restriction on the build workflow, so we always get a status check
- Update actions to their latest tags
- Update action.yml to use Node 16 and increment the minor version for the action
- Update actions/core to v1.10.0 to handle [untrusted logged data](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

## PR Requirements
- [x] For JavaScript actions, the action has been recompiled.  
  - See the *Recompiling* section of the repository's README.md for more details.
  - This does not apply to Composite Run Steps actions unless a package.json is present and contains a build script.
- [x] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
- [x] The examples in the repository's `README.md` have been updated with the new version.  
  - See the *Incrementing the Version* section of the repository's README.md for more details on how the version will be incremented.
- [x] The action code does not contain sensitive information.
