### PR TITLE
EN-23497 - Adding option to download from Redgate Url

### DIFF
--- a/.github/workflows/build-and-review-pr.yml
+++ b/.github/workflows/build-and-review-pr.yml
@@ -21,6 +21,10 @@ on:
   #   without disabling that requirement.  If we have a status check that is always produced,
   #   we can also use that to require all branches be up to date before they are merged.
 
+concurrency:
+  group: ci-${{ github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   build-and-review-pr:
     # This reusable workflow will check to see if an action's source code has changed based on

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,10 @@ on:
     # check that our Branch Protection Rules can use.  Having a status check also allows us
     # to require that branches be up to date before they are merged.
 
+concurrency:
+  group: test-flyway-${{ github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   test-flyway-version-514:
     runs-on: ${{ matrix.operating-system }}
@@ -25,6 +29,7 @@ jobs:
         uses: ./
         with:
           version: 5.1.4
+
       - name: Check Version
         id: flyway-version
         shell: pwsh
@@ -49,11 +54,38 @@ jobs:
         uses: ./
         with:
           version: 7.0.0
+
       - name: Check Version
         id: flyway-version
         shell: pwsh
         run: |
           $FlywayVersion = flyway -v
           if(-Not ($FlywayVersion -Match "7.0.0")) {
+            exit code 1
+          }
+
+  test-flyway-version-10181-redgate:
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      fail-fast: false
+      matrix:
+        operating-system: [ubuntu-latest, windows-latest, macOS-latest]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Flyway
+        uses: ./
+        with:
+          version: 10.18.1
+          use-redgate-url: true
+
+      - name: Check Version
+        id: flyway-version
+        shell: pwsh
+        run: |
+          $FlywayVersion = flyway -v
+          if(-Not ($FlywayVersion -Match "10.18.1")) {
             exit code 1
           }

--- a/README.md
+++ b/README.md
@@ -17,10 +17,11 @@ This action downloads and installs [Flyway](https://flywaydb.org/) via the [Acti
 
 ## Inputs
 
-| Parameter      | Is Required | Description                                                                                                          |
-|----------------|-------------|----------------------------------------------------------------------------------------------------------------------|
-| `version`      | true        | The version of Flyway to install                                                                                     |
-| `architecture` | false       | Target operating system architecture for Flyway to use. Examples: x86, x64. Will use system architecture by default. |
+| Parameter         | Is Required | Description                                                                                                          |
+|----------------   |-------------|----------------------------------------------------------------------------------------------------------------------|
+| `version`         | true        | The version of Flyway to install                                                                                     |
+| `architecture`    | false       | Target operating system architecture for Flyway to use. Examples: x86, x64. Will use system architecture by default. |
+| `use-redgate-url` | false       | Use the flyway tarball from the Redgate URL. If false, will pull from maven url. Default is false.                   |
 
 ## Usage Examples
 
@@ -35,9 +36,31 @@ jobs:
 
       - name: Setup Flyway
         # You may also reference the major or major.minor version
-        uses: im-open/setup-flyway@v1.3.0
+        uses: im-open/setup-flyway@v1.3.1
         with:
-          version: 5.1.4
+          version: 10.18.1
+
+      - name: Migrate Database
+        run: flyway migrate
+```
+
+***Using Redgate URL**
+
+```yml
+jobs:
+  migrate-database:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Flyway
+        # You may also reference the major or major.minor version
+        uses: im-open/setup-flyway@v1.3.1
+        with:
+          version: 10.18.1
+          use-redgate-url: true
 
       - name: Migrate Database
         run: flyway migrate

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,10 @@ inputs:
   architecture:
     description: 'Target operating system architecture for Flyway to use. Examples: x86, x64. Will use system architecture by default.'
     required: false
+  use-redgate-url:
+    description: 'Use the flyway tarball from the Redgate URL. If false, will pull from maven url. Default is false.'
+    required: false
+    default: false
 runs:
   using: 'node20'
   main: 'dist/index.js'

--- a/src/installer.js
+++ b/src/installer.js
@@ -4,7 +4,7 @@ const tc = require('@actions/tool-cache');
 const path = require('path');
 const fs = require('fs');
 
-export async function getFlyway(versionSpec, osArch = os.arch()) {
+export async function getFlyway(versionSpec, osArch = os.arch(), useRedgateUrl = false) {
   let osPlat = os.platform();
 
   // check cache
@@ -17,7 +17,7 @@ export async function getFlyway(versionSpec, osArch = os.arch()) {
   } else {
     core.info(`Attempting to download ${versionSpec}...`);
     let downloadPath = '';
-    let info = (await getInfoFromDist(versionSpec, osArch)) || {};
+    let info = (await getInfoFromDist(versionSpec, osArch, useRedgateUrl)) || {};
 
     //
     // Download from Flyway
@@ -76,7 +76,7 @@ export async function getFlyway(versionSpec, osArch = os.arch()) {
   core.addPath(driversPath);
 }
 
-async function getInfoFromDist(version, osArch = os.arch()) {
+async function getInfoFromDist(version, osArch = os.arch(), useRedgateUrl = false) {
   let osPlat = os.platform();
   core.info(`Current Operating System Platform: ${osPlat}`);
   let fileName = osPlat === 'win32' ? `flyway-commandline-${version}-windows-${osArch}` : '';
@@ -84,8 +84,9 @@ async function getInfoFromDist(version, osArch = os.arch()) {
     fileName || (osPlat === 'linux' ? `flyway-commandline-${version}-linux-${osArch}` : '');
   fileName = fileName || `flyway-commandline-${version}-macosx-x64`; // If not windows or linux, then mac and there is only one arch for mac
   let urlFileName = osPlat == 'win32' ? `${fileName}.zip` : `${fileName}.tar.gz`;
-  let url = `https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/${version}/${urlFileName}`;
-
+  let mavenUrl = `https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/${version}/${urlFileName}`;
+  let redgateUrl = `https://download.red-gate.com/maven/release/com/redgate/flyway/flyway-commandline/${version}/${urlFileName}`;
+  let url = useRedgateUrl ? redgateUrl : mavenUrl;
   return {
     downloadUrl: url,
     resolvedVersion: version,

--- a/src/main.js
+++ b/src/main.js
@@ -6,12 +6,13 @@ async function run() {
   try {
     const version = core.getInput('version', { required: true });
     let osArchitecture = core.getInput('architecture');
+    const useRedgateUrl = core.getInput('use-redgate-url') == 'true';
 
     if (!osArchitecture) {
       osArchitecture = os.arch();
     }
 
-    await installer.getFlyway(version, osArchitecture);
+    await installer.getFlyway(version, osArchitecture, useRedgateUrl);
   } catch (error) {
     core.setFailed(error.message);
   }


### PR DESCRIPTION
# Summary of PR changes
* Adding input to use Redgate download url.
* The Redgate binary is more up to date and not broken when using Azure AD authentication method


## PR Requirements
- [x] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
- [x] The action code does not contain sensitive information.

*NOTE: If the repo's workflow could not automatically update the `README.md`, it should be updated manually with the next version.  For javascript actions, if the repo's workflow could not automatically recompile the action it should also be updated manually as part of the PR.*
